### PR TITLE
hotfix/asset-eception-message

### DIFF
--- a/aiof.asset.core/AssetExceptionMiddleware.cs
+++ b/aiof.asset.core/AssetExceptionMiddleware.cs
@@ -74,7 +74,10 @@ namespace aiof.asset.core
             };
 
             if (e is AssetException ae)
+            {
                 problem.Code = ae.StatusCode;
+                problem.Message = ae.Message;
+            }
             else if (e is ValidationException ve)
             {
                 problem.Code = StatusCodes.Status400BadRequest;


### PR DESCRIPTION
Hotfix for `AssetException` message. It happens when there is an asset exception thrown. The middleware doesn't update the message that is attached to the exception, but uses the default one instead

![image](https://user-images.githubusercontent.com/11888479/114434906-8d698c80-9b91-11eb-93a7-c4cdbb298bb7.png)
![image](https://user-images.githubusercontent.com/11888479/114434986-a2462000-9b91-11eb-9400-92d670aad034.png)
