### PR TITLE
feature/add-eventing-feature-flag

### DIFF
--- a/aiof.asset.core/Startup.cs
+++ b/aiof.asset.core/Startup.cs
@@ -31,6 +31,7 @@ namespace aiof.asset.core
         {
             services.AddScoped<IAssetRepository, AssetRepository>()
                 .AddScoped<IEventRepository, EventRepository>()
+                .AddScoped<IEnvConfiguration, EnvConfiguration>()
                 .AddScoped<ITenant, Tenant>()
                 .AddAutoMapper(typeof(AutoMappingProfile).Assembly);
 

--- a/aiof.asset.core/appsettings.Development.json
+++ b/aiof.asset.core/appsettings.Development.json
@@ -9,6 +9,9 @@
       "Microsoft.Hosting.Lifetime": "Information"
     }
   },
+  "FeatureManagement": {
+    "Eventing": false
+  },
   "Data": {
     "PostgreSQL": "Server=127.0.0.1;Port=5433;Database=aiof;User Id=aiof;Password=aiofiscool;"
   },

--- a/aiof.asset.data/Constants.cs
+++ b/aiof.asset.data/Constants.cs
@@ -129,4 +129,9 @@ namespace aiof.asset.data
         public const string Cash = "cash";
         public const string Other = "other";
     }
+
+    public enum FeatureFlags
+    {
+        Eventing
+    }
 }

--- a/aiof.asset.data/EnvConfiguration.cs
+++ b/aiof.asset.data/EnvConfiguration.cs
@@ -1,0 +1,30 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+using Microsoft.Extensions.Configuration;
+using Microsoft.FeatureManagement;
+
+namespace aiof.asset.data
+{
+    public class EnvConfiguration : IEnvConfiguration
+    {
+        public readonly IConfiguration _config;
+        public readonly IFeatureManager _featureManager;
+
+        public EnvConfiguration(
+            IConfiguration config,
+            IFeatureManager featureManager)
+        {
+            _config = config ?? throw new ArgumentNullException(nameof(config));
+            _featureManager = featureManager ?? throw new ArgumentNullException(nameof(featureManager));
+        }
+
+        public async Task<bool> IsEnabledAsync(FeatureFlags featureFlag)
+        {
+            return await _featureManager.IsEnabledAsync(featureFlag.ToString());
+        }
+    }
+}

--- a/aiof.asset.data/IEnvConfiguration.cs
+++ b/aiof.asset.data/IEnvConfiguration.cs
@@ -1,0 +1,13 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace aiof.asset.data
+{
+    public interface IEnvConfiguration
+    {
+        Task<bool> IsEnabledAsync(FeatureFlags featureFlag);
+    }
+}

--- a/aiof.asset.data/aiof.asset.data.csproj
+++ b/aiof.asset.data/aiof.asset.data.csproj
@@ -9,6 +9,7 @@
     <PackageReference Include="FluentValidation" Version="10.0.4" />
     <PackageReference Include="Microsoft.AspNetCore.Http" Version="2.2.2" />
     <PackageReference Include="Microsoft.EntityFrameworkCore" Version="5.0.4" />
+    <PackageReference Include="Microsoft.FeatureManagement.AspNetCore" Version="2.3.0" />
     <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="5.0.2" />
   </ItemGroup>
 

--- a/aiof.asset.tests/Helper.cs
+++ b/aiof.asset.tests/Helper.cs
@@ -9,6 +9,7 @@ using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.AspNetCore.Http;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.FeatureManagement;
 
 using AutoMapper;
 using FluentValidation;
@@ -33,7 +34,8 @@ namespace aiof.asset.tests
             {
                 { Keys.EventingBaseUrl, "http://test" },
                 { Keys.EventingFunctionKeyHeaderName, "x-functions-key" },
-                { Keys.EventingFunctionKey, "functionkey" }
+                { Keys.EventingFunctionKey, "functionkey" },
+                { "FeatureManagement:Eventing", "true" }
             };
 
         public T GetRequiredService<T>()
@@ -52,6 +54,7 @@ namespace aiof.asset.tests
 
             services.AddScoped<IAssetRepository, AssetRepository>()
                 .AddScoped<IEventRepository, EventRepository>()
+                .AddScoped<IEnvConfiguration, EnvConfiguration>()
                 .AddScoped<ITenant, Tenant>()
                 .AddScoped<FakeDataManager>();
 
@@ -81,6 +84,7 @@ namespace aiof.asset.tests
                 .AddScoped<AbstractValidator<AssetStockDto>, AssetStockDtoValidator>();
 
             services.AddLogging();
+            services.AddFeatureManagement();
             services.AddHttpContextAccessor();
 
             return services;


### PR DESCRIPTION
Feature to add eventing feature flag. This gives us the capability to turn the eventing feature on and off based on a configuration setup.

- added `EnvConfiguration`

```csharp
public class EnvConfiguration : IEnvConfiguration
{
    public readonly IConfiguration _config;
    public readonly IFeatureManager _featureManager;

    public EnvConfiguration(
        IConfiguration config,
        IFeatureManager featureManager)
    {
        _config = config ?? throw new ArgumentNullException(nameof(config));
        _featureManager = featureManager ?? throw new ArgumentNullException(nameof(featureManager));
    }

    public async Task<bool> IsEnabledAsync(FeatureFlags featureFlag)
    {
        return await _featureManager.IsEnabledAsync(featureFlag.ToString());
    }
}
```

- added Feature flags enum in `Constants.cs`

```csharp
public enum FeatureFlags
{
    Eventing
}
```

- added `IsEnabledAsync` function to check feature flags

```csharp
public async Task<bool> IsEnabledAsync(FeatureFlags featureFlag)
{
    return await _featureManager.IsEnabledAsync(featureFlag.ToString());
}
```

- updated unit tests `Helper.cs` to add feature management
- added iac app settings changes kamacharovs/aiof-iac#4