### PR TITLE
hotfix/2021.08/update-restsharp-version

### DIFF
--- a/aiof.asset.core/aiof.asset.core.csproj
+++ b/aiof.asset.core/aiof.asset.core.csproj
@@ -14,7 +14,7 @@
     <PackageReference Include="Microsoft.EntityFrameworkCore" Version="5.0.4" />
     <PackageReference Include="Microsoft.FeatureManagement.AspNetCore" Version="2.3.0" />
     <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="5.0.2" />
-    <PackageReference Include="RestSharp" Version="106.11.7" />
+    <PackageReference Include="RestSharp" Version="106.12.0" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.1.3" />
   </ItemGroup>
 

--- a/aiof.asset.services/aiof.asset.services.csproj
+++ b/aiof.asset.services/aiof.asset.services.csproj
@@ -7,7 +7,7 @@
   <ItemGroup>
     <PackageReference Include="FluentValidation" Version="10.0.4" />
     <PackageReference Include="Polly" Version="7.2.2" />
-    <PackageReference Include="RestSharp" Version="106.11.7" />
+    <PackageReference Include="RestSharp" Version="106.12.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/aiof.asset.tests/aiof.asset.tests.csproj
+++ b/aiof.asset.tests/aiof.asset.tests.csproj
@@ -13,7 +13,7 @@
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="5.0.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.7.1" />
     <PackageReference Include="Moq" Version="4.16.1" />
-    <PackageReference Include="RestSharp" Version="106.11.7" />
+    <PackageReference Include="RestSharp" Version="106.12.0" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>


### PR DESCRIPTION
Updated RestSharp library version to `106.12.0` to avoid security concerns and issues