### PR TITLE
feature/2021.08/add-asset-home

### DIFF
--- a/aiof.asset.core/Controllers/AssetController.cs
+++ b/aiof.asset.core/Controllers/AssetController.cs
@@ -106,6 +106,18 @@ namespace aiof.asset.core
         }
 
         /// <summary>
+        /// Add Asset.Home
+        /// </summary>
+        [HttpPost]
+        [Route("home")]
+        [ProducesResponseType(typeof(IAssetProblemDetail), StatusCodes.Status400BadRequest)]
+        [ProducesResponseType(typeof(IAsset), StatusCodes.Status201Created)]
+        public async Task<IActionResult> AddHomeAsync([FromBody, Required] AssetHomeDto dto)
+        {
+            return Created(nameof(AssetHome), await _repo.AddAsync(dto));
+        }
+
+        /// <summary>
         /// Add Asset snapshot
         /// </summary>
         [HttpPost]

--- a/aiof.asset.core/Controllers/AssetController.cs
+++ b/aiof.asset.core/Controllers/AssetController.cs
@@ -94,30 +94,6 @@ namespace aiof.asset.core
         }
 
         /// <summary>
-        /// Add Asset.Stock
-        /// </summary>
-        [HttpPost]
-        [Route("stock")]
-        [ProducesResponseType(typeof(IAssetProblemDetail), StatusCodes.Status400BadRequest)]
-        [ProducesResponseType(typeof(IAsset), StatusCodes.Status201Created)]
-        public async Task<IActionResult> AddAsync([FromBody, Required] AssetStockDto dto)
-        {
-            return Created(nameof(AssetStock), await _repo.AddAsync(dto));
-        }
-
-        /// <summary>
-        /// Add Asset.Home
-        /// </summary>
-        [HttpPost]
-        [Route("home")]
-        [ProducesResponseType(typeof(IAssetProblemDetail), StatusCodes.Status400BadRequest)]
-        [ProducesResponseType(typeof(IAsset), StatusCodes.Status201Created)]
-        public async Task<IActionResult> AddAsync([FromBody, Required] AssetHomeDto dto)
-        {
-            return Created(nameof(AssetHome), await _repo.AddAsync(dto));
-        }
-
-        /// <summary>
         /// Add Asset snapshot
         /// </summary>
         [HttpPost]
@@ -139,34 +115,6 @@ namespace aiof.asset.core
         public async Task<IActionResult> UpdateAsync(
             [FromRoute, Required] int id,
             [FromBody, Required] AssetDto dto)
-        {
-            return Ok(await _repo.UpdateAsync(id, dto));
-        }
-
-        /// <summary>
-        /// Update Asset.Stock
-        /// </summary>
-        [HttpPut]
-        [Route("stock/{id}")]
-        [ProducesResponseType(typeof(IAssetProblemDetail), StatusCodes.Status400BadRequest)]
-        [ProducesResponseType(typeof(IAssetSnapshot), StatusCodes.Status200OK)]
-        public async Task<IActionResult> UpdateAsync(
-            [FromRoute, Required] int id,
-            [FromBody, Required] AssetStockDto dto)
-        {
-            return Ok(await _repo.UpdateAsync(id, dto));
-        }
-
-        /// <summary>
-        /// Update Asset.Home
-        /// </summary>
-        [HttpPut]
-        [Route("home/{id}")]
-        [ProducesResponseType(typeof(IAssetProblemDetail), StatusCodes.Status400BadRequest)]
-        [ProducesResponseType(typeof(IAssetSnapshot), StatusCodes.Status200OK)]
-        public async Task<IActionResult> UpdateAsync(
-            [FromRoute, Required] int id,
-            [FromBody, Required] AssetHomeDto dto)
         {
             return Ok(await _repo.UpdateAsync(id, dto));
         }

--- a/aiof.asset.core/Controllers/AssetController.cs
+++ b/aiof.asset.core/Controllers/AssetController.cs
@@ -100,7 +100,7 @@ namespace aiof.asset.core
         [Route("stock")]
         [ProducesResponseType(typeof(IAssetProblemDetail), StatusCodes.Status400BadRequest)]
         [ProducesResponseType(typeof(IAsset), StatusCodes.Status201Created)]
-        public async Task<IActionResult> AddStockAsync([FromBody, Required] AssetStockDto dto)
+        public async Task<IActionResult> AddAsync([FromBody, Required] AssetStockDto dto)
         {
             return Created(nameof(AssetStock), await _repo.AddAsync(dto));
         }
@@ -112,7 +112,7 @@ namespace aiof.asset.core
         [Route("home")]
         [ProducesResponseType(typeof(IAssetProblemDetail), StatusCodes.Status400BadRequest)]
         [ProducesResponseType(typeof(IAsset), StatusCodes.Status201Created)]
-        public async Task<IActionResult> AddHomeAsync([FromBody, Required] AssetHomeDto dto)
+        public async Task<IActionResult> AddAsync([FromBody, Required] AssetHomeDto dto)
         {
             return Created(nameof(AssetHome), await _repo.AddAsync(dto));
         }
@@ -153,6 +153,20 @@ namespace aiof.asset.core
         public async Task<IActionResult> UpdateAsync(
             [FromRoute, Required] int id,
             [FromBody, Required] AssetStockDto dto)
+        {
+            return Ok(await _repo.UpdateAsync(id, dto));
+        }
+
+        /// <summary>
+        /// Update Asset.Home
+        /// </summary>
+        [HttpPut]
+        [Route("home/{id}")]
+        [ProducesResponseType(typeof(IAssetProblemDetail), StatusCodes.Status400BadRequest)]
+        [ProducesResponseType(typeof(IAssetSnapshot), StatusCodes.Status200OK)]
+        public async Task<IActionResult> UpdateAsync(
+            [FromRoute, Required] int id,
+            [FromBody, Required] AssetHomeDto dto)
         {
             return Ok(await _repo.UpdateAsync(id, dto));
         }

--- a/aiof.asset.core/Controllers/AssetHomeController.cs
+++ b/aiof.asset.core/Controllers/AssetHomeController.cs
@@ -1,0 +1,58 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using System.ComponentModel.DataAnnotations;
+
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Authorization;
+
+using aiof.asset.data;
+using aiof.asset.services;
+
+namespace aiof.asset.core
+{
+    [Authorize]
+    [ApiController]
+    [ApiVersion(Constants.ApiV1)]
+    [Route(Constants.ApiHomeRoute)]
+    [Produces(Constants.ApplicationJson)]
+    [Consumes(Constants.ApplicationJson)]
+    [ProducesResponseType(typeof(IAssetProblemDetail), StatusCodes.Status500InternalServerError)]
+    [ProducesResponseType(typeof(IAssetProblemDetailBase), StatusCodes.Status403Forbidden)]
+    [ProducesResponseType(typeof(IAssetProblemDetailBase), StatusCodes.Status401Unauthorized)]
+    public class AssetHomeController : ControllerBase
+    {
+        private readonly IAssetHomeRepository _repo;
+
+        public AssetHomeController(IAssetHomeRepository repo)
+        {
+            _repo = repo ?? throw new ArgumentNullException(nameof(repo));
+        }
+
+        /// <summary>
+        /// Add Asset.Home
+        /// </summary>
+        [HttpPost]
+        [ProducesResponseType(typeof(IAssetProblemDetail), StatusCodes.Status400BadRequest)]
+        [ProducesResponseType(typeof(IAsset), StatusCodes.Status201Created)]
+        public async Task<IActionResult> AddAsync([FromBody, Required] AssetHomeDto dto)
+        {
+            return Created(nameof(AssetHome), await _repo.AddAsync(dto));
+        }
+       
+        /// <summary>
+        /// Update Asset.Home
+        /// </summary>
+        [HttpPut]
+        [Route("{id}")]
+        [ProducesResponseType(typeof(IAssetProblemDetail), StatusCodes.Status400BadRequest)]
+        [ProducesResponseType(typeof(IAssetSnapshot), StatusCodes.Status200OK)]
+        public async Task<IActionResult> UpdateAsync(
+            [FromRoute, Required] int id,
+            [FromBody, Required] AssetHomeDto dto)
+        {
+            return Ok(await _repo.UpdateAsync(id, dto));
+        }
+    }
+}

--- a/aiof.asset.core/Controllers/AssetStockController.cs
+++ b/aiof.asset.core/Controllers/AssetStockController.cs
@@ -1,0 +1,58 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using System.ComponentModel.DataAnnotations;
+
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Authorization;
+
+using aiof.asset.data;
+using aiof.asset.services;
+
+namespace aiof.asset.core
+{
+    [Authorize]
+    [ApiController]
+    [ApiVersion(Constants.ApiV1)]
+    [Route(Constants.ApiStockRoute)]
+    [Produces(Constants.ApplicationJson)]
+    [Consumes(Constants.ApplicationJson)]
+    [ProducesResponseType(typeof(IAssetProblemDetail), StatusCodes.Status500InternalServerError)]
+    [ProducesResponseType(typeof(IAssetProblemDetailBase), StatusCodes.Status403Forbidden)]
+    [ProducesResponseType(typeof(IAssetProblemDetailBase), StatusCodes.Status401Unauthorized)]
+    public class AssetStockController : ControllerBase
+    {
+        private readonly IAssetStockRepository _repo;
+
+        public AssetStockController(IAssetStockRepository repo)
+        {
+            _repo = repo ?? throw new ArgumentNullException(nameof(repo));
+        }
+
+        /// <summary>
+        /// Add Asset.Stock
+        /// </summary>
+        [HttpPost]
+        [ProducesResponseType(typeof(IAssetProblemDetail), StatusCodes.Status400BadRequest)]
+        [ProducesResponseType(typeof(IAsset), StatusCodes.Status201Created)]
+        public async Task<IActionResult> AddAsync([FromBody, Required] AssetStockDto dto)
+        {
+            return Created(nameof(AssetStock), await _repo.AddAsync(dto));
+        }
+
+        /// <summary>
+        /// Update Asset.Stock
+        /// </summary>
+        [HttpPut]
+        [Route("{id}")]
+        [ProducesResponseType(typeof(IAssetProblemDetail), StatusCodes.Status400BadRequest)]
+        [ProducesResponseType(typeof(IAssetSnapshot), StatusCodes.Status200OK)]
+        public async Task<IActionResult> UpdateAsync(
+            [FromRoute, Required] int id,
+            [FromBody, Required] AssetStockDto dto)
+        {
+            return Ok(await _repo.UpdateAsync(id, dto));
+        }
+    }
+}

--- a/aiof.asset.core/MiddlewareExtensions.cs
+++ b/aiof.asset.core/MiddlewareExtensions.cs
@@ -78,7 +78,8 @@ namespace aiof.asset.core
             services.AddScoped<AbstractValidator<string>, AssetTypeValidator>()
                 .AddScoped<AbstractValidator<AssetDto>, AssetDtoValidator>()
                 .AddScoped<AbstractValidator<AssetSnapshotDto>, AssetSnapshotDtoValidator>()
-                .AddScoped<AbstractValidator<AssetStockDto>, AssetStockDtoValidator>();
+                .AddScoped<AbstractValidator<AssetStockDto>, AssetStockDtoValidator>()
+                .AddScoped<AbstractValidator<AssetHomeDto>, AssetHomeDtoValidator>();
 
             return services;
         }

--- a/aiof.asset.core/Startup.cs
+++ b/aiof.asset.core/Startup.cs
@@ -30,6 +30,8 @@ namespace aiof.asset.core
         public void ConfigureServices(IServiceCollection services)
         {
             services.AddScoped<IAssetRepository, AssetRepository>()
+                .AddScoped<IAssetStockRepository, AssetStockRepository>()
+                .AddScoped<IAssetHomeRepository, AssetHomeRepository>()
                 .AddScoped<IEventRepository, EventRepository>()
                 .AddScoped<IEnvConfiguration, EnvConfiguration>()
                 .AddScoped<ITenant, Tenant>()

--- a/aiof.asset.data/Asset.Home.cs
+++ b/aiof.asset.data/Asset.Home.cs
@@ -1,3 +1,4 @@
+using System;
 using System.ComponentModel.DataAnnotations;
 
 namespace aiof.asset.data
@@ -24,7 +25,7 @@ namespace aiof.asset.data
     {
         public string HomeType { get; set; }
         public double? LoanValue { get; set; }
-        public double? Mortgage { get; set; }
+        public double? MonthlyMortgage { get; set; }
         public double? MortgageRate { get; set; }
         public double? DownPayment { get; set; }
         public double? AnnualInsurance { get; set; }

--- a/aiof.asset.data/Asset.Home.cs
+++ b/aiof.asset.data/Asset.Home.cs
@@ -6,13 +6,13 @@ namespace aiof.asset.data
     public class AssetHome : Asset
     {
         public string HomeType { get; set; }
-        public double LoanValue { get; set; }
-        public double MonthlyMortgage { get; set; }
-        public double MortgageRate { get; set; }
-        public double DownPayment { get; set; }
-        public double? AnnualInsurance { get; set; }
-        public double? AnnualPropertyTax { get; set; }
-        public double? ClosingCosts { get; set; }
+        public decimal LoanValue { get; set; }
+        public decimal MonthlyMortgage { get; set; }
+        public decimal MortgageRate { get; set; }
+        public decimal DownPayment { get; set; }
+        public decimal? AnnualInsurance { get; set; }
+        public decimal? AnnualPropertyTax { get; set; }
+        public decimal? ClosingCosts { get; set; }
         public bool? IsRefinanced { get; set; } = false;
 
         public AssetHome()
@@ -23,15 +23,17 @@ namespace aiof.asset.data
 
     public class AssetHomeDto : AssetDto
     {
+        [MaxLength(100)]
         public string HomeType { get; set; }
-        public double? LoanValue { get; set; }
-        public double? MonthlyMortgage { get; set; }
-        public double? MortgageRate { get; set; }
-        public double? DownPayment { get; set; }
-        public double? AnnualInsurance { get; set; }
-        public double? AnnualPropertyTax { get; set; }
-        public double? ClosingCosts { get; set; }
-        public bool? Refinanced { get; set; }
+
+        public decimal? LoanValue { get; set; }
+        public decimal? MonthlyMortgage { get; set; }
+        public decimal? MortgageRate { get; set; }
+        public decimal? DownPayment { get; set; }
+        public decimal? AnnualInsurance { get; set; }
+        public decimal? AnnualPropertyTax { get; set; }
+        public decimal? ClosingCosts { get; set; }
+        public bool? IsRefinanced { get; set; }
 
         public AssetHomeDto()
         {

--- a/aiof.asset.data/Asset.Home.cs
+++ b/aiof.asset.data/Asset.Home.cs
@@ -1,0 +1,35 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace aiof.asset.data
+{
+    public class AssetHome : Asset
+    {
+        public string HomeType { get; set; }
+        public double LoanValue { get; set; }
+        public double Mortgage { get; set; }
+        public double MortgageRate { get; set; }
+        public double DownPayment { get; set; }
+        public double? AnnualInsurance { get; set; }
+        public double? AnnualPropertyTax { get; set; }
+        public double? ClosingCosts { get; set; }
+        public bool Refinanced { get; set; } = false;
+
+        public AssetHome()
+        {
+            TypeName = AssetTypes.Home;
+        }
+    }
+
+    public class AssetHomeDto : AssetDto
+    {
+        public string HomeType { get; set; }
+        public double LoanValue { get; set; }
+        public double Mortgage { get; set; }
+        public double MortgageRate { get; set; }
+        public double DownPayment { get; set; }
+        public double? AnnualInsurance { get; set; }
+        public double? AnnualPropertyTax { get; set; }
+        public double? ClosingCosts { get; set; }
+        public bool Refinanced { get; set; } = false;
+    }
+}

--- a/aiof.asset.data/Asset.Home.cs
+++ b/aiof.asset.data/Asset.Home.cs
@@ -32,5 +32,10 @@ namespace aiof.asset.data
         public double? AnnualPropertyTax { get; set; }
         public double? ClosingCosts { get; set; }
         public bool? Refinanced { get; set; }
+
+        public AssetHomeDto()
+        {
+            TypeName = AssetTypes.Home;
+        }
     }
 }

--- a/aiof.asset.data/Asset.Home.cs
+++ b/aiof.asset.data/Asset.Home.cs
@@ -23,13 +23,13 @@ namespace aiof.asset.data
     public class AssetHomeDto : AssetDto
     {
         public string HomeType { get; set; }
-        public double LoanValue { get; set; }
-        public double Mortgage { get; set; }
-        public double MortgageRate { get; set; }
-        public double DownPayment { get; set; }
+        public double? LoanValue { get; set; }
+        public double? Mortgage { get; set; }
+        public double? MortgageRate { get; set; }
+        public double? DownPayment { get; set; }
         public double? AnnualInsurance { get; set; }
         public double? AnnualPropertyTax { get; set; }
         public double? ClosingCosts { get; set; }
-        public bool Refinanced { get; set; } = false;
+        public bool? Refinanced { get; set; };
     }
 }

--- a/aiof.asset.data/Asset.Home.cs
+++ b/aiof.asset.data/Asset.Home.cs
@@ -6,13 +6,13 @@ namespace aiof.asset.data
     {
         public string HomeType { get; set; }
         public double LoanValue { get; set; }
-        public double Mortgage { get; set; }
+        public double MonthlyMortgage { get; set; }
         public double MortgageRate { get; set; }
         public double DownPayment { get; set; }
         public double? AnnualInsurance { get; set; }
         public double? AnnualPropertyTax { get; set; }
         public double? ClosingCosts { get; set; }
-        public bool Refinanced { get; set; } = false;
+        public bool? IsRefinanced { get; set; } = false;
 
         public AssetHome()
         {
@@ -30,6 +30,6 @@ namespace aiof.asset.data
         public double? AnnualInsurance { get; set; }
         public double? AnnualPropertyTax { get; set; }
         public double? ClosingCosts { get; set; }
-        public bool? Refinanced { get; set; };
+        public bool? Refinanced { get; set; }
     }
 }

--- a/aiof.asset.data/Asset.Home.cs
+++ b/aiof.asset.data/Asset.Home.cs
@@ -34,10 +34,5 @@ namespace aiof.asset.data
         public decimal? AnnualPropertyTax { get; set; }
         public decimal? ClosingCosts { get; set; }
         public bool? IsRefinanced { get; set; }
-
-        public AssetHomeDto()
-        {
-            TypeName = AssetTypes.Home;
-        }
     }
 }

--- a/aiof.asset.data/Asset.Stock.cs
+++ b/aiof.asset.data/Asset.Stock.cs
@@ -5,9 +5,9 @@ namespace aiof.asset.data
     public class AssetStock : Asset
     {
         public string TickerSymbol { get; set; }
-        public double? Shares { get; set; }
-        public double? ExpenseRatio { get; set; }
-        public double? DividendYield { get; set; }
+        public decimal? Shares { get; set; }
+        public decimal? ExpenseRatio { get; set; }
+        public decimal? DividendYield { get; set; }
 
         public AssetStock()
         {
@@ -20,9 +20,9 @@ namespace aiof.asset.data
         [MaxLength(50)]
         public string TickerSymbol { get; set; }
 
-        public double? Shares { get; set; }
-        public double? ExpenseRatio { get; set; }
-        public double? DividendYield { get; set; }
+        public decimal? Shares { get; set; }
+        public decimal? ExpenseRatio { get; set; }
+        public decimal? DividendYield { get; set; }
 
         public AssetStockDto()
         {

--- a/aiof.asset.data/Asset.Stock.cs
+++ b/aiof.asset.data/Asset.Stock.cs
@@ -23,10 +23,5 @@ namespace aiof.asset.data
         public decimal? Shares { get; set; }
         public decimal? ExpenseRatio { get; set; }
         public decimal? DividendYield { get; set; }
-
-        public AssetStockDto()
-        {
-            TypeName = AssetTypes.Stock;
-        }
     }
 }

--- a/aiof.asset.data/Asset.Stock.cs
+++ b/aiof.asset.data/Asset.Stock.cs
@@ -23,5 +23,10 @@ namespace aiof.asset.data
         public double? Shares { get; set; }
         public double? ExpenseRatio { get; set; }
         public double? DividendYield { get; set; }
+
+        public AssetStockDto()
+        {
+            TypeName = AssetTypes.Stock;
+        }
     }
 }

--- a/aiof.asset.data/AssetContext.cs
+++ b/aiof.asset.data/AssetContext.cs
@@ -79,10 +79,10 @@ namespace aiof.asset.data
                 e.ToTable(Keys.Entity.AssetHome);
 
                 e.Property(x => x.HomeType).HasSnakeCaseColumnName().HasMaxLength(100).IsRequired();
-                e.Property(x => x.LoanValue).HasSnakeCaseColumnName().IsRequired();
-                e.Property(x => x.MonthlyMortgage).HasSnakeCaseColumnName().IsRequired();
-                e.Property(x => x.MortgageRate).HasSnakeCaseColumnName().IsRequired();
-                e.Property(x => x.DownPayment).HasSnakeCaseColumnName().IsRequired();
+                e.Property(x => x.LoanValue).HasSnakeCaseColumnName();
+                e.Property(x => x.MonthlyMortgage).HasSnakeCaseColumnName();
+                e.Property(x => x.MortgageRate).HasSnakeCaseColumnName();
+                e.Property(x => x.DownPayment).HasSnakeCaseColumnName();
                 e.Property(x => x.AnnualInsurance).HasSnakeCaseColumnName();
                 e.Property(x => x.AnnualPropertyTax).HasSnakeCaseColumnName();
                 e.Property(x => x.ClosingCosts).HasSnakeCaseColumnName();

--- a/aiof.asset.data/AssetContext.cs
+++ b/aiof.asset.data/AssetContext.cs
@@ -11,6 +11,7 @@ namespace aiof.asset.data
         public virtual DbSet<AssetType> AssetTypes { get; set; }
         public virtual DbSet<Asset> Assets { get; set; }
         public virtual DbSet<AssetStock> AssetsStock { get; set; }
+        public virtual DbSet<AssetHome> AssetsHome { get; set; }
         public virtual DbSet<AssetSnapshot> AssetSnapshots { get; set; }
 
         public AssetContext(DbContextOptions<AssetContext> options, ITenant tenant)
@@ -71,6 +72,21 @@ namespace aiof.asset.data
                 e.Property(x => x.Shares).HasSnakeCaseColumnName();
                 e.Property(x => x.ExpenseRatio).HasSnakeCaseColumnName();
                 e.Property(x => x.DividendYield).HasSnakeCaseColumnName();
+            });
+
+            modelBuilder.Entity<AssetHome>(e =>
+            {
+                e.ToTable(Keys.Entity.AssetHome);
+
+                e.Property(x => x.HomeType).HasSnakeCaseColumnName().HasMaxLength(100).IsRequired();
+                e.Property(x => x.LoanValue).HasSnakeCaseColumnName().IsRequired();
+                e.Property(x => x.MonthlyMortgage).HasSnakeCaseColumnName().IsRequired();
+                e.Property(x => x.MortgageRate).HasSnakeCaseColumnName().IsRequired();
+                e.Property(x => x.DownPayment).HasSnakeCaseColumnName().IsRequired();
+                e.Property(x => x.AnnualInsurance).HasSnakeCaseColumnName();
+                e.Property(x => x.AnnualPropertyTax).HasSnakeCaseColumnName();
+                e.Property(x => x.ClosingCosts).HasSnakeCaseColumnName();
+                e.Property(x => x.IsRefinanced).HasSnakeCaseColumnName();
             });
 
             modelBuilder.Entity<AssetSnapshot>(e =>

--- a/aiof.asset.data/AssetEvent.cs
+++ b/aiof.asset.data/AssetEvent.cs
@@ -6,7 +6,7 @@ using System.Threading.Tasks;
 
 namespace aiof.asset.data
 {
-    public class AssetEvent
+    public abstract class AssetEvent
     {
         public string EventType { get; set; }
         public EventSource Source { get; set; } = new EventSource();
@@ -30,6 +30,7 @@ namespace aiof.asset.data
         public object Payload { get; set; }
     }
 
+    #region Events
     public class AssetAddedEvent : AssetEvent
     {
         public AssetAddedEvent()
@@ -51,4 +52,5 @@ namespace aiof.asset.data
             EventType = Constants.AssetDeletedEvent;
         }
     }
+    #endregion
 }

--- a/aiof.asset.data/AssetValidator.cs
+++ b/aiof.asset.data/AssetValidator.cs
@@ -27,14 +27,6 @@ namespace aiof.asset.data
                 : false;
         }
 
-        public static bool BeValidPercent(double? value)
-        {
-            var valuePerc = Math.Round((double)(value * 100), 4);
-
-            return value.HasValue
-                ? valuePerc > 0 && valuePerc <= 100
-                : false;
-        }
         public static bool BeValidPercent(decimal? value)
         {
             var valuePerc = Math.Round((decimal)(value * 100), 4);

--- a/aiof.asset.data/AssetValidator.cs
+++ b/aiof.asset.data/AssetValidator.cs
@@ -229,7 +229,32 @@ namespace aiof.asset.data
                 RuleFor(x => x)
                     .NotNull()
                     .SetValidator(new AssetDtoValidator(_context));
- 
+
+                RuleFor(x => x.HomeType)
+                    .NotEmpty()
+                    .MaximumLength(100);
+
+                RuleFor(x => x.LoanValue)
+                    .NotEmpty()
+                    .GreaterThanOrEqualTo(CommonValidator.MinimumValue)
+                    .LessThanOrEqualTo(CommonValidator.MaximumValue);
+
+                RuleFor(x => x.MonthlyMortgage)
+                    .NotEmpty()
+                    .GreaterThanOrEqualTo(CommonValidator.MinimumValue)
+                    .LessThanOrEqualTo(CommonValidator.MaximumValue);
+
+                RuleFor(x => x.MortgageRate)
+                    .NotEmpty()
+                    .GreaterThanOrEqualTo(CommonValidator.MinimumPercentValue)
+                    .LessThanOrEqualTo(CommonValidator.MaximumPercentValue);
+
+                RuleFor(x => x.DownPayment)
+                    .NotEmpty()
+                    .GreaterThanOrEqualTo(CommonValidator.MinimumValue)
+                    .LessThanOrEqualTo(CommonValidator.MaximumValue);
+
+                SetCommonRules();
             });
 
             RuleSet(Constants.UpdateStockRuleSet, () =>
@@ -237,7 +262,63 @@ namespace aiof.asset.data
                 RuleFor(x => x)
                     .NotNull()
                     .SetValidator(new AssetDtoValidator(_context));
+
+                RuleFor(x => x.HomeType)
+                    .NotEmpty()
+                    .MaximumLength(100)
+                    .When(x => x.HomeType != null);
+
+                RuleFor(x => x.LoanValue)
+                    .NotEmpty()
+                    .GreaterThanOrEqualTo(CommonValidator.MinimumValue)
+                    .LessThanOrEqualTo(CommonValidator.MaximumValue)
+                    .When(x => x.LoanValue.HasValue);
+
+                RuleFor(x => x.MonthlyMortgage)
+                    .NotEmpty()
+                    .GreaterThanOrEqualTo(CommonValidator.MinimumValue)
+                    .LessThanOrEqualTo(CommonValidator.MaximumValue)
+                    .When(x => x.MonthlyMortgage.HasValue);
+
+                RuleFor(x => x.MortgageRate)
+                    .NotEmpty()
+                    .GreaterThanOrEqualTo(CommonValidator.MinimumPercentValue)
+                    .LessThanOrEqualTo(CommonValidator.MaximumPercentValue)
+                    .When(x => x.MortgageRate.HasValue);
+
+                RuleFor(x => x.DownPayment)
+                    .NotEmpty()
+                    .GreaterThanOrEqualTo(CommonValidator.MinimumValue)
+                    .LessThanOrEqualTo(CommonValidator.MaximumValue)
+                    .When(x => x.DownPayment.HasValue);
+
+                SetCommonRules();
             });
+        }
+
+        public void SetCommonRules()
+        {
+            RuleFor(x => x.AnnualInsurance)
+                .NotEmpty()
+                .GreaterThanOrEqualTo(CommonValidator.MinimumValue)
+                .LessThanOrEqualTo(CommonValidator.MaximumValue)
+                .When(x => x.AnnualInsurance.HasValue);
+
+            RuleFor(x => x.AnnualPropertyTax)
+                .NotEmpty()
+                .GreaterThanOrEqualTo(CommonValidator.MinimumPercentValue)
+                .LessThanOrEqualTo(CommonValidator.MaximumPercentValue)
+                .When(x => x.AnnualPropertyTax.HasValue);
+
+            RuleFor(x => x.ClosingCosts)
+                .NotEmpty()
+                .GreaterThanOrEqualTo(CommonValidator.MinimumValue)
+                .LessThanOrEqualTo(CommonValidator.MaximumValue)
+                .When(x => x.ClosingCosts.HasValue);
+
+            RuleFor(x => x.IsRefinanced)
+                .NotEmpty()
+                .When(x => x.IsRefinanced.HasValue);
         }
     }
 

--- a/aiof.asset.data/AssetValidator.cs
+++ b/aiof.asset.data/AssetValidator.cs
@@ -44,6 +44,8 @@ namespace aiof.asset.data
             RuleSet(Constants.UpdateRuleSet, () => { SetTypeRules(); });
             RuleSet(Constants.AddStockRuleSet, () => { SetTypeRules(); });
             RuleSet(Constants.UpdateStockRuleSet, () => { SetTypeRules(); });
+            RuleSet(Constants.AddHomeRuleSet, () => { SetTypeRules(); });
+            RuleSet(Constants.UpdateHomeRuleSet, () => { SetTypeRules(); });
             RuleSet(Constants.AddSnapshotRuleSet, () => { SetTypeRules(); });
             RuleSet(Constants.UpdateSnapshotRuleSet, () => { SetTypeRules(); });
 
@@ -76,9 +78,11 @@ namespace aiof.asset.data
 
             RuleSet(Constants.AddRuleSet, () => { SetAddRules(); });
             RuleSet(Constants.AddStockRuleSet, () => { SetAddRules(); });
+            RuleSet(Constants.AddHomeRuleSet, () => { SetAddRules(); });
 
             RuleSet(Constants.UpdateRuleSet, () => { SetUpdateRules(); });
             RuleSet(Constants.UpdateStockRuleSet, () => { SetUpdateRules(); });
+            RuleSet(Constants.UpdateHomeRuleSet, () => { SetUpdateRules(); });
         }
 
         public void SetAddRules()
@@ -206,6 +210,33 @@ namespace aiof.asset.data
                     })
                     .WithMessage(CommonValidator.PercentValueMessage)
                     .When(x => x.DividendYield.HasValue);
+            });
+        }
+    }
+
+    public class AssetHomeDtoValidator : AbstractValidator<AssetHomeDto>
+    {
+        private readonly AssetContext _context;
+
+        public AssetHomeDtoValidator(AssetContext context)
+        {
+            ValidatorOptions.Global.CascadeMode = CascadeMode.Stop;
+
+            _context = context ?? throw new ArgumentNullException(nameof(context));
+
+            RuleSet(Constants.AddStockRuleSet, () =>
+            {
+                RuleFor(x => x)
+                    .NotNull()
+                    .SetValidator(new AssetDtoValidator(_context));
+ 
+            });
+
+            RuleSet(Constants.UpdateStockRuleSet, () =>
+            {
+                RuleFor(x => x)
+                    .NotNull()
+                    .SetValidator(new AssetDtoValidator(_context));
             });
         }
     }

--- a/aiof.asset.data/AssetValidator.cs
+++ b/aiof.asset.data/AssetValidator.cs
@@ -145,12 +145,10 @@ namespace aiof.asset.data
 
             _context = context ?? throw new ArgumentNullException(nameof(context));
 
+            Include(new AssetDtoValidator(_context));
+
             RuleSet(Constants.AddStockRuleSet, () =>
             {
-                RuleFor(x => x)
-                    .NotNull()
-                    .SetValidator(new AssetDtoValidator(_context));
-
                 RuleFor(x => x.TickerSymbol)
                     .NotEmpty()
                     .MaximumLength(50);
@@ -180,10 +178,6 @@ namespace aiof.asset.data
 
             RuleSet(Constants.UpdateStockRuleSet, () =>
             {
-                RuleFor(x => x)
-                    .NotNull()
-                    .SetValidator(new AssetDtoValidator(_context));
-
                 RuleFor(x => x.TickerSymbol)
                     .NotEmpty()
                     .MaximumLength(50)
@@ -224,12 +218,10 @@ namespace aiof.asset.data
 
             _context = context ?? throw new ArgumentNullException(nameof(context));
 
+            Include(new AssetDtoValidator(_context));
+
             RuleSet(Constants.AddStockRuleSet, () =>
             {
-                RuleFor(x => x)
-                    .NotNull()
-                    .SetValidator(new AssetDtoValidator(_context));
-
                 RuleFor(x => x.HomeType)
                     .NotEmpty()
                     .MaximumLength(100);
@@ -259,10 +251,6 @@ namespace aiof.asset.data
 
             RuleSet(Constants.UpdateStockRuleSet, () =>
             {
-                RuleFor(x => x)
-                    .NotNull()
-                    .SetValidator(new AssetDtoValidator(_context));
-
                 RuleFor(x => x.HomeType)
                     .NotEmpty()
                     .MaximumLength(100)

--- a/aiof.asset.data/AssetValidator.cs
+++ b/aiof.asset.data/AssetValidator.cs
@@ -20,9 +20,24 @@ namespace aiof.asset.data
 
         public static string AssetUpdateMessage = $"You must specify at least one field to update. '{nameof(AssetDto.Name)}', '{nameof(AssetDto.TypeName)}' or '{nameof(AssetDto.Value)}'";
 
+        public static bool BeValidValue(decimal? value)
+        {
+            return value.HasValue
+                ? value >= MinimumValue && value <= MaximumValue
+                : false;
+        }
+
         public static bool BeValidPercent(double? value)
         {
             var valuePerc = Math.Round((double)(value * 100), 4);
+
+            return value.HasValue
+                ? valuePerc > 0 && valuePerc <= 100
+                : false;
+        }
+        public static bool BeValidPercent(decimal? value)
+        {
+            var valuePerc = Math.Round((decimal)(value * 100), 4);
 
             return value.HasValue
                 ? valuePerc > 0 && valuePerc <= 100
@@ -97,8 +112,7 @@ namespace aiof.asset.data
 
             RuleFor(x => x.Value)
                 .NotNull()
-                .GreaterThanOrEqualTo(CommonValidator.MinimumValue)
-                .LessThan(CommonValidator.MaximumValue)
+                .Must(CommonValidator.BeValidValue)
                 .WithMessage(CommonValidator.ValueMessage);
         }
 
@@ -128,8 +142,7 @@ namespace aiof.asset.data
                 .When(x => x.TypeName != null);
 
             RuleFor(x => x.Value)
-                .GreaterThanOrEqualTo(CommonValidator.MinimumValue)
-                .LessThan(CommonValidator.MaximumValue)
+                .Must(CommonValidator.BeValidValue)
                 .WithMessage(CommonValidator.ValueMessage)
                 .When(x => x.Value.HasValue);
         }
@@ -159,19 +172,13 @@ namespace aiof.asset.data
 
                 RuleFor(x => x.ExpenseRatio)
                     .GreaterThan(0)
-                    .Must(x =>
-                    {
-                        return CommonValidator.BeValidPercent(x);
-                    })
+                    .Must(CommonValidator.BeValidPercent)
                     .WithMessage(CommonValidator.PercentValueMessage)
                     .When(x => x.ExpenseRatio.HasValue);
 
                 RuleFor(x => x.DividendYield)
                     .GreaterThan(0)
-                    .Must(x =>
-                    {
-                        return CommonValidator.BeValidPercent(x);
-                    })
+                    .Must(CommonValidator.BeValidPercent)
                     .WithMessage(CommonValidator.PercentValueMessage)
                     .When(x => x.DividendYield.HasValue);
             });
@@ -189,19 +196,13 @@ namespace aiof.asset.data
 
                 RuleFor(x => x.ExpenseRatio)
                     .GreaterThan(0)
-                    .Must(x =>
-                    {
-                        return CommonValidator.BeValidPercent(x);
-                    })
+                    .Must(CommonValidator.BeValidPercent)
                     .WithMessage(CommonValidator.PercentValueMessage)
                     .When(x => x.ExpenseRatio.HasValue);
 
                 RuleFor(x => x.DividendYield)
                     .GreaterThan(0)
-                    .Must(x =>
-                    {
-                        return CommonValidator.BeValidPercent(x);
-                    })
+                    .Must(CommonValidator.BeValidPercent)
                     .WithMessage(CommonValidator.PercentValueMessage)
                     .When(x => x.DividendYield.HasValue);
             });
@@ -228,23 +229,19 @@ namespace aiof.asset.data
 
                 RuleFor(x => x.LoanValue)
                     .NotEmpty()
-                    .GreaterThanOrEqualTo(CommonValidator.MinimumValue)
-                    .LessThanOrEqualTo(CommonValidator.MaximumValue);
+                    .Must(CommonValidator.BeValidValue);
 
                 RuleFor(x => x.MonthlyMortgage)
                     .NotEmpty()
-                    .GreaterThanOrEqualTo(CommonValidator.MinimumValue)
-                    .LessThanOrEqualTo(CommonValidator.MaximumValue);
+                    .Must(CommonValidator.BeValidValue);
 
                 RuleFor(x => x.MortgageRate)
                     .NotEmpty()
-                    .GreaterThanOrEqualTo(CommonValidator.MinimumPercentValue)
-                    .LessThanOrEqualTo(CommonValidator.MaximumPercentValue);
+                    .Must(CommonValidator.BeValidPercent);
 
                 RuleFor(x => x.DownPayment)
                     .NotEmpty()
-                    .GreaterThanOrEqualTo(CommonValidator.MinimumValue)
-                    .LessThanOrEqualTo(CommonValidator.MaximumValue);
+                    .Must(CommonValidator.BeValidValue);
 
                 SetCommonRules();
             });
@@ -258,26 +255,22 @@ namespace aiof.asset.data
 
                 RuleFor(x => x.LoanValue)
                     .NotEmpty()
-                    .GreaterThanOrEqualTo(CommonValidator.MinimumValue)
-                    .LessThanOrEqualTo(CommonValidator.MaximumValue)
+                    .Must(CommonValidator.BeValidValue)
                     .When(x => x.LoanValue.HasValue);
 
                 RuleFor(x => x.MonthlyMortgage)
                     .NotEmpty()
-                    .GreaterThanOrEqualTo(CommonValidator.MinimumValue)
-                    .LessThanOrEqualTo(CommonValidator.MaximumValue)
+                    .Must(CommonValidator.BeValidValue)
                     .When(x => x.MonthlyMortgage.HasValue);
 
                 RuleFor(x => x.MortgageRate)
                     .NotEmpty()
-                    .GreaterThanOrEqualTo(CommonValidator.MinimumPercentValue)
-                    .LessThanOrEqualTo(CommonValidator.MaximumPercentValue)
+                    .Must(CommonValidator.BeValidPercent)
                     .When(x => x.MortgageRate.HasValue);
 
                 RuleFor(x => x.DownPayment)
                     .NotEmpty()
-                    .GreaterThanOrEqualTo(CommonValidator.MinimumValue)
-                    .LessThanOrEqualTo(CommonValidator.MaximumValue)
+                    .Must(CommonValidator.BeValidValue)
                     .When(x => x.DownPayment.HasValue);
 
                 SetCommonRules();
@@ -288,20 +281,17 @@ namespace aiof.asset.data
         {
             RuleFor(x => x.AnnualInsurance)
                 .NotEmpty()
-                .GreaterThanOrEqualTo(CommonValidator.MinimumValue)
-                .LessThanOrEqualTo(CommonValidator.MaximumValue)
+                .Must(CommonValidator.BeValidValue)
                 .When(x => x.AnnualInsurance.HasValue);
 
             RuleFor(x => x.AnnualPropertyTax)
                 .NotEmpty()
-                .GreaterThanOrEqualTo(CommonValidator.MinimumPercentValue)
-                .LessThanOrEqualTo(CommonValidator.MaximumPercentValue)
+                .Must(CommonValidator.BeValidValue)
                 .When(x => x.AnnualPropertyTax.HasValue);
 
             RuleFor(x => x.ClosingCosts)
                 .NotEmpty()
-                .GreaterThanOrEqualTo(CommonValidator.MinimumValue)
-                .LessThanOrEqualTo(CommonValidator.MaximumValue)
+                .Must(CommonValidator.BeValidValue)
                 .When(x => x.ClosingCosts.HasValue);
 
             RuleFor(x => x.IsRefinanced)
@@ -344,8 +334,7 @@ namespace aiof.asset.data
                 .When(x => x.TypeName != null);
 
             RuleFor(x => x.Value)
-                .GreaterThanOrEqualTo(CommonValidator.MinimumValue)
-                .LessThan(CommonValidator.MaximumValue)
+                .Must(CommonValidator.BeValidValue)
                 .WithMessage(CommonValidator.ValueMessage)
                 .When(x => x.Value.HasValue);
         }

--- a/aiof.asset.data/AssetValidator.cs
+++ b/aiof.asset.data/AssetValidator.cs
@@ -118,7 +118,8 @@ namespace aiof.asset.data
                         x.Name is null
                         && x.TypeName is null
                         && !x.Value.HasValue
-                        && type != nameof(AssetStockDto);
+                        && type != nameof(AssetStockDto)
+                        && type != nameof(AssetHomeDto);
 
                     return !areAllNull;
                 })

--- a/aiof.asset.data/AutoMappingProfile.cs
+++ b/aiof.asset.data/AutoMappingProfile.cs
@@ -46,6 +46,16 @@ namespace aiof.asset.data
 
             CreateMap<AssetStockDto, AssetSnapshotDto>()
                 .ForAllMembers(x => x.Condition((source, destination, member) => member != null));
+
+            /*
+             * Asset.Home
+             */
+            CreateMap<AssetHomeDto, AssetHome>()
+                .ForAllMembers(x => x.Condition((source, destination, member) => member != null));
+
+            CreateMap<AssetHomeDto, AssetSnapshotDto>()
+                .ForAllMembers(x => x.Condition((source, destination, member) => member != null));
+
         }
     }
 

--- a/aiof.asset.data/AutoMappingProfile.cs
+++ b/aiof.asset.data/AutoMappingProfile.cs
@@ -42,19 +42,40 @@ namespace aiof.asset.data
              * Asset.Stock
              */
             CreateMap<AssetStockDto, AssetStock>()
-                .ForAllMembers(x => x.Condition((source, destination, member) => member != null));
+                .ForMember(x => x.Name, o => o.Condition(s => !string.IsNullOrWhiteSpace(s.Name)))
+                .ForMember(x => x.TypeName, o => o.Condition(s => !string.IsNullOrWhiteSpace(s.TypeName)))
+                .ForMember(x => x.Value, o => o.Condition(s => s.Value.HasValue))
+                .ForMember(x => x.TickerSymbol, o => o.Condition(s => !string.IsNullOrWhiteSpace(s.TickerSymbol)))
+                .ForMember(x => x.Shares, o => o.Condition(s => s.Shares.HasValue))
+                .ForMember(x => x.ExpenseRatio, o => o.Condition(s => s.ExpenseRatio.HasValue))
+                .ForMember(x => x.DividendYield, o => o.Condition(s => s.DividendYield.HasValue));
 
             CreateMap<AssetStockDto, AssetSnapshotDto>()
-                .ForAllMembers(x => x.Condition((source, destination, member) => member != null));
+                .ForMember(x => x.Name, o => o.Condition(s => !string.IsNullOrWhiteSpace(s.Name)))
+                .ForMember(x => x.TypeName, o => o.Condition(s => !string.IsNullOrWhiteSpace(s.TypeName)))
+                .ForMember(x => x.Value, o => o.Condition(s => s.Value.HasValue));
 
             /*
              * Asset.Home
              */
             CreateMap<AssetHomeDto, AssetHome>()
-                .ForAllMembers(x => x.Condition((source, destination, member) => member != null));
+                .ForMember(x => x.Name, o => o.Condition(s => !string.IsNullOrWhiteSpace(s.Name)))
+                .ForMember(x => x.TypeName, o => o.Condition(s => !string.IsNullOrWhiteSpace(s.TypeName)))
+                .ForMember(x => x.Value, o => o.Condition(s => s.Value.HasValue))
+                .ForMember(x => x.HomeType, o => o.Condition(s => !string.IsNullOrWhiteSpace(s.HomeType)))
+                .ForMember(x => x.LoanValue, o => o.Condition(s => s.LoanValue.HasValue))
+                .ForMember(x => x.MonthlyMortgage, o => o.Condition(s => s.MonthlyMortgage.HasValue))
+                .ForMember(x => x.MortgageRate, o => o.Condition(s => s.MortgageRate.HasValue))
+                .ForMember(x => x.DownPayment, o => o.Condition(s => s.DownPayment.HasValue))
+                .ForMember(x => x.AnnualInsurance, o => o.Condition(s => s.AnnualInsurance.HasValue))
+                .ForMember(x => x.AnnualPropertyTax, o => o.Condition(s => s.AnnualPropertyTax.HasValue))
+                .ForMember(x => x.ClosingCosts, o => o.Condition(s => s.ClosingCosts.HasValue))
+                .ForMember(x => x.IsRefinanced, o => o.Condition(s => s.IsRefinanced.HasValue));
 
             CreateMap<AssetHomeDto, AssetSnapshotDto>()
-                .ForAllMembers(x => x.Condition((source, destination, member) => member != null));
+                .ForMember(x => x.Name, o => o.Condition(s => !string.IsNullOrWhiteSpace(s.Name)))
+                .ForMember(x => x.TypeName, o => o.Condition(s => !string.IsNullOrWhiteSpace(s.TypeName)))
+                .ForMember(x => x.Value, o => o.Condition(s => s.Value.HasValue));
 
         }
     }

--- a/aiof.asset.data/Constants.cs
+++ b/aiof.asset.data/Constants.cs
@@ -9,9 +9,11 @@ namespace aiof.asset.data
     {
         public const string AddRuleSet = nameof(AddRuleSet);
         public const string AddStockRuleSet = nameof(AddStockRuleSet);
+        public const string AddHomeRuleSet = nameof(AddHomeRuleSet);
         public const string AddSnapshotRuleSet = nameof(AddSnapshotRuleSet);
         public const string UpdateRuleSet = nameof(UpdateRuleSet);
         public const string UpdateStockRuleSet = nameof(UpdateStockRuleSet);
+        public const string UpdateHomeRuleSet = nameof(UpdateHomeRuleSet);
         public const string UpdateSnapshotRuleSet = nameof(UpdateSnapshotRuleSet);
 
         public const string Accept = nameof(Accept);
@@ -113,9 +115,10 @@ namespace aiof.asset.data
 
         public static class Entity
         {
+            public static string AssetType = nameof(data.AssetType).ToSnakeCase();
             public static string Asset = nameof(data.Asset).ToSnakeCase();
             public static string AssetStock = nameof(data.AssetStock).ToSnakeCase();
-            public static string AssetType = nameof(data.AssetType).ToSnakeCase();
+            public static string AssetHome = nameof(data.AssetHome).ToSnakeCase();
             public static string AssetSnapshot = nameof(data.AssetSnapshot).ToSnakeCase();
         }
     }

--- a/aiof.asset.data/Constants.cs
+++ b/aiof.asset.data/Constants.cs
@@ -58,7 +58,8 @@ namespace aiof.asset.data
         public static Dictionary<string, string> ClassToTypeMap
             => new Dictionary<string, string>
             {
-                { typeof(AssetStock).Name, AssetTypes.Stock }
+                { typeof(AssetStock).Name, AssetTypes.Stock },
+                { typeof(AssetHome).Name, AssetTypes.Home }
             };
     }
 
@@ -126,7 +127,6 @@ namespace aiof.asset.data
     public static class AssetTypes
     {
         public const string Car = "car";
-        public const string House = "house";
         public const string Investment = "investment";
         public const string Stock = "stock";
         public const string Home = "home";

--- a/aiof.asset.data/Constants.cs
+++ b/aiof.asset.data/Constants.cs
@@ -27,6 +27,8 @@ namespace aiof.asset.data
 
         public const string ApiName = "aiof-asset";
         public const string ApiRoute = "v{version:apiVersion}/assets";
+        public const string ApiStockRoute = "v{version:apiVersion}/assets/stock";
+        public const string ApiHomeRoute = "v{version:apiVersion}/assets/home";
         public const string ApiV1 = "1.0";
         public static string ApiV1Full = $"v{ApiV1}";
         public static string[] ApiSupportedVersions

--- a/aiof.asset.data/Constants.cs
+++ b/aiof.asset.data/Constants.cs
@@ -126,6 +126,7 @@ namespace aiof.asset.data
         public const string House = "house";
         public const string Investment = "investment";
         public const string Stock = "stock";
+        public const string Home = "home";
         public const string Cash = "cash";
         public const string Other = "other";
     }

--- a/aiof.asset.data/ExtensionMethods.cs
+++ b/aiof.asset.data/ExtensionMethods.cs
@@ -1,14 +1,16 @@
 using System;
+using System.Linq;
 using System.Threading.Tasks;
 
 using FluentValidation;
 using FluentValidation.Results;
+using AutoMapper;
 
 namespace aiof.asset.data
 {
     public static class ExtensionMethods
     {
-        #region Validate adAsset
+        #region Validate AddAsset
         public static async Task<ValidationResult> ValidateAddAssetAsync<T>(
             this IValidator<T> validator, 
             T dto)
@@ -32,6 +34,30 @@ namespace aiof.asset.data
             T dto)
         {
             await validator.ValidateAndThrowUpdateAsync(dto, Constants.UpdateRuleSet);
+        }
+        private static async Task ValidateAndThrowAddAsync<T>(
+            this IValidator<T> validator,
+            T dto,
+            string ruleSet)
+        {
+            var result = await validator.ValidateAsync(dto, o => o.IncludeRuleSets(ruleSet));
+
+            if (!result.IsValid)
+            {
+                throw new ValidationException(result.Errors);
+            }
+        }
+        private static async Task ValidateAndThrowUpdateAsync<T>(
+            this IValidator<T> validator,
+            T dto,
+            string ruleSet)
+        {
+            var result = await validator.ValidateAsync(dto, o => o.IncludeRuleSets(ruleSet));
+
+            if (!result.IsValid)
+            {
+                throw new ValidationException(result.Errors);
+            }
         }
         #endregion
 
@@ -87,31 +113,17 @@ namespace aiof.asset.data
         {
             await validator.ValidateAndThrowUpdateAsync(dto, Constants.UpdateSnapshotRuleSet);
         }
+        #endregion     
+
+        #region Automapper
+        public static T MergeInto<T>(this IMapper mapper, params object[] objects)
+        {
+            var first = mapper.Map<T>(objects.First());
+
+            return objects
+                .Skip(1)
+                .Aggregate(first, (r, obj) => mapper.Map(obj, r));
+        }
         #endregion
-
-        private static async Task ValidateAndThrowAddAsync<T>(
-            this IValidator<T> validator, 
-            T dto,
-            string ruleSet)
-        {
-            var result = await validator.ValidateAsync(dto, o => o.IncludeRuleSets(ruleSet));
-
-            if (!result.IsValid)
-            {
-                throw new ValidationException(result.Errors);
-            }
-        }
-        private static async Task ValidateAndThrowUpdateAsync<T>(
-            this IValidator<T> validator, 
-            T dto,
-            string ruleSet)
-        {
-            var result = await validator.ValidateAsync(dto, o => o.IncludeRuleSets(ruleSet));
-
-            if (!result.IsValid)
-            {
-                throw new ValidationException(result.Errors);
-            }
-        }
     }
 }

--- a/aiof.asset.data/ExtensionMethods.cs
+++ b/aiof.asset.data/ExtensionMethods.cs
@@ -10,33 +10,33 @@ namespace aiof.asset.data
 {
     public static class ExtensionMethods
     {
-        #region Validate AddAsset
-        public static async Task<ValidationResult> ValidateAddAssetAsync<T>(
-            this IValidator<T> validator, 
-            T dto)
+        #region Validate Asset
+        public static async Task<ValidationResult> ValidateAddAssetAsync<T>(this AbstractValidator<T> validator, T dto)
+            where T : AssetDto
         {
             return await validator.ValidateAsync(dto, o => o.IncludeRuleSets(Constants.AddRuleSet));
         }
-        public static async Task<ValidationResult> ValidateUpdateAssetAsync<T>(
-            this IValidator<T> validator, 
-            T dto)
+
+        public static async Task<ValidationResult> ValidateUpdateAssetAsync<T>(this AbstractValidator<T> validator, T dto)
+            where T : AssetDto
         {
             return await validator.ValidateAsync(dto, o => o.IncludeRuleSets(Constants.UpdateRuleSet));
         }
-        public static async Task ValidateAndThrowAddAssetAsync<T>(
-            this IValidator<T> validator, 
-            T dto)
+
+        public static async Task ValidateAndThrowAddAssetAsync<T>(this AbstractValidator<T> validator, T dto)
+            where T : AssetDto
         {
             await validator.ValidateAndThrowAddAsync(dto, Constants.AddRuleSet);
         }
-        public static async Task ValidateAndThrowUpdateAssetAsync<T>(
-            this IValidator<T> validator, 
-            T dto)
+
+        public static async Task ValidateAndThrowUpdateAssetAsync<T>(this AbstractValidator<T> validator, T dto)
+            where T : AssetDto
         {
             await validator.ValidateAndThrowUpdateAsync(dto, Constants.UpdateRuleSet);
         }
+
         private static async Task ValidateAndThrowAddAsync<T>(
-            this IValidator<T> validator,
+            this AbstractValidator<T> validator,
             T dto,
             string ruleSet)
         {
@@ -47,8 +47,9 @@ namespace aiof.asset.data
                 throw new ValidationException(result.Errors);
             }
         }
+
         private static async Task ValidateAndThrowUpdateAsync<T>(
-            this IValidator<T> validator,
+            this AbstractValidator<T> validator,
             T dto,
             string ruleSet)
         {
@@ -62,81 +63,78 @@ namespace aiof.asset.data
         #endregion
 
         #region Validate Stock
-        public static async Task<ValidationResult> ValidateAddStockAsync<T>(
-            this IValidator<T> validator, 
-            T dto)
+        public static async Task<ValidationResult> ValidateAddStockAsync<T>(this AbstractValidator<T> validator, T dto)
+            where T : AssetStockDto
         {
             return await validator.ValidateAsync(dto, o => o.IncludeRuleSets(Constants.AddStockRuleSet));
         }
-        public static async Task<ValidationResult> ValidateUpdateStockAsync<T>(
-            this IValidator<T> validator, 
-            T dto)
+
+        public static async Task<ValidationResult> ValidateUpdateStockAsync<T>(this AbstractValidator<T> validator, T dto)
+            where T : AssetStockDto
         {
             return await validator.ValidateAsync(dto, o => o.IncludeRuleSets(Constants.UpdateStockRuleSet));
         }
-        public static async Task ValidateAndThrowAddStockAsync<T>(
-            this IValidator<T> validator, 
-            T dto)
+
+        public static async Task ValidateAndThrowAddStockAsync<T>(this AbstractValidator<T> validator, T dto)
+            where T : AssetStockDto
         {
             await validator.ValidateAndThrowAddAsync(dto, Constants.AddStockRuleSet);
         }
-        public static async Task ValidateAndThrowUpdateStockAsync<T>(
-            this IValidator<T> validator, 
-            T dto)
+
+        public static async Task ValidateAndThrowUpdateStockAsync<T>(this AbstractValidator<T> validator, T dto)
+            where T : AssetStockDto
         {
             await validator.ValidateAndThrowUpdateAsync(dto, Constants.UpdateStockRuleSet);
         }
         #endregion
 
         #region Validate Home
-        public static async Task<ValidationResult> ValidateAddHomeAsync<T>(
-            this IValidator<T> validator,
-            T dto)
+        public static async Task<ValidationResult> ValidateAddHomeAsync<T>(this AbstractValidator<T> validator, T dto)
+            where T : AssetHomeDto
         {
             return await validator.ValidateAsync(dto, o => o.IncludeRuleSets(Constants.AddHomeRuleSet));
         }
-        public static async Task<ValidationResult> ValidateUpdateHomeAsync<T>(
-            this IValidator<T> validator,
-            T dto)
+
+        public static async Task<ValidationResult> ValidateUpdateHomeAsync<T>(this AbstractValidator<T> validator, T dto)
+            where T : AssetHomeDto
         {
             return await validator.ValidateAsync(dto, o => o.IncludeRuleSets(Constants.UpdateHomeRuleSet));
         }
-        public static async Task ValidateAndThrowAddHomeAsync<T>(
-            this IValidator<T> validator,
-            T dto)
+
+        public static async Task ValidateAndThrowAddHomeAsync<T>(this AbstractValidator<T> validator, T dto)
+            where T : AssetHomeDto
         {
             await validator.ValidateAndThrowAddAsync(dto, Constants.AddHomeRuleSet);
         }
-        public static async Task ValidateAndThrowUpdateHomeAsync<T>(
-            this IValidator<T> validator,
-            T dto)
+
+        public static async Task ValidateAndThrowUpdateHomeAsync<T>(this AbstractValidator<T> validator, T dto)
+            where T : AssetHomeDto
         {
             await validator.ValidateAndThrowUpdateAsync(dto, Constants.UpdateHomeRuleSet);
         }
         #endregion
 
         #region Validate Snapshot
-        public static async Task<ValidationResult> ValidateAddSnapshotAsync<T>(
-            this IValidator<T> validator, 
-            T dto)
+        public static async Task<ValidationResult> ValidateAddSnapshotAsync<T>(this AbstractValidator<T> validator, T dto)
+            where T : AssetSnapshotDto
         {
             return await validator.ValidateAsync(dto, o => o.IncludeRuleSets(Constants.AddSnapshotRuleSet));
         }
-        public static async Task<ValidationResult> ValidateUpdateSnapshotAsync<T>(
-            this IValidator<T> validator, 
-            T dto)
+
+        public static async Task<ValidationResult> ValidateUpdateSnapshotAsync<T>(this AbstractValidator<T> validator, T dto)
+            where T : AssetSnapshotDto
         {
             return await validator.ValidateAsync(dto, o => o.IncludeRuleSets(Constants.UpdateSnapshotRuleSet));
         }
-        public static async Task ValidateAndThrowAddSnapshotAsync<T>(
-            this IValidator<T> validator, 
-            T dto)
+
+        public static async Task ValidateAndThrowAddSnapshotAsync<T>(this AbstractValidator<T> validator, T dto)
+            where T : AssetSnapshotDto
         {
             await validator.ValidateAndThrowAddAsync(dto, Constants.AddSnapshotRuleSet);
         }
-        public static async Task ValidateAndThrowUpdateSnapshotAsync<T>(
-            this IValidator<T> validator, 
-            T dto)
+
+        public static async Task ValidateAndThrowUpdateSnapshotAsync<T>(this AbstractValidator<T> validator, T dto)
+            where T : AssetSnapshotDto
         {
             await validator.ValidateAndThrowUpdateAsync(dto, Constants.UpdateSnapshotRuleSet);
         }

--- a/aiof.asset.data/ExtensionMethods.cs
+++ b/aiof.asset.data/ExtensionMethods.cs
@@ -88,6 +88,33 @@ namespace aiof.asset.data
         }
         #endregion
 
+        #region Validate Home
+        public static async Task<ValidationResult> ValidateAddHomeAsync<T>(
+            this IValidator<T> validator,
+            T dto)
+        {
+            return await validator.ValidateAsync(dto, o => o.IncludeRuleSets(Constants.AddHomeRuleSet));
+        }
+        public static async Task<ValidationResult> ValidateUpdateHomeAsync<T>(
+            this IValidator<T> validator,
+            T dto)
+        {
+            return await validator.ValidateAsync(dto, o => o.IncludeRuleSets(Constants.UpdateHomeRuleSet));
+        }
+        public static async Task ValidateAndThrowAddHomeAsync<T>(
+            this IValidator<T> validator,
+            T dto)
+        {
+            await validator.ValidateAndThrowAddAsync(dto, Constants.AddHomeRuleSet);
+        }
+        public static async Task ValidateAndThrowUpdateHomeAsync<T>(
+            this IValidator<T> validator,
+            T dto)
+        {
+            await validator.ValidateAndThrowUpdateAsync(dto, Constants.UpdateHomeRuleSet);
+        }
+        #endregion
+
         #region Validate Snapshot
         public static async Task<ValidationResult> ValidateAddSnapshotAsync<T>(
             this IValidator<T> validator, 

--- a/aiof.asset.data/ExtensionMethods.cs
+++ b/aiof.asset.data/ExtensionMethods.cs
@@ -150,5 +150,14 @@ namespace aiof.asset.data
                 .Aggregate(first, (r, obj) => mapper.Map(obj, r));
         }
         #endregion
+
+        #region Generic
+        public static bool IsValid(this AssetSnapshotDto dto)
+        {
+            return dto.Name is not null
+                || dto.TypeName is not null
+                || dto.Value.HasValue;
+        }
+        #endregion
     }
 }

--- a/aiof.asset.data/FakeDataManager.cs
+++ b/aiof.asset.data/FakeDataManager.cs
@@ -123,9 +123,9 @@ namespace aiof.asset.data
                     Created = DateTime.UtcNow.AddYears(-1),
                     IsDeleted = false,
                     TickerSymbol = "VTSAX",
-                    Shares = 149.658,
-                    ExpenseRatio = 0.040,
-                    DividendYield = 1.36
+                    Shares = 149.658M,
+                    ExpenseRatio = 0.040M,
+                    DividendYield = 1.36M
                 }
             };
         }

--- a/aiof.asset.data/FakeDataManager.cs
+++ b/aiof.asset.data/FakeDataManager.cs
@@ -26,6 +26,9 @@ namespace aiof.asset.data
             _context.AssetsStock
                 .AddRange(GetFakeAssetsStock());
 
+            _context.AssetsHome
+                .AddRange(GetFakeAssetsHome());
+
             _context.AssetSnapshots
                 .AddRange(GetFakeAssetSnapshots());
 
@@ -130,6 +133,30 @@ namespace aiof.asset.data
             };
         }
 
+        public IEnumerable<AssetHome> GetFakeAssetsHome()
+        {
+            return new List<AssetHome>
+            {
+                new AssetHome
+                {
+                    Id = 6,
+                    Name = "asset.home",
+                    Value = 375000M,
+                    UserId = 1,
+                    Created = DateTime.UtcNow.AddDays(-1),
+                    IsDeleted = false,
+                    HomeType = "apartment",
+                    LoanValue = 335000M,
+                    MonthlyMortgage = 1756.23M,
+                    MortgageRate = 2.625M,
+                    DownPayment = 40000M,
+                    AnnualInsurance = 1.25M,
+                    AnnualPropertyTax = 1.01M,
+                    ClosingCosts = 16000M
+                }
+            };
+        }
+
         public IEnumerable<AssetSnapshot> GetFakeAssetSnapshots()
         {
             return new List<AssetSnapshot>
@@ -199,6 +226,16 @@ namespace aiof.asset.data
                     Value = 10500M,
                     ValueChange = 0,
                     Created = DateTime.UtcNow.AddYears(-1)
+                },
+                new AssetSnapshot
+                {
+                    Id = 8,
+                    AssetId = 6,
+                    Name = "asset.home",
+                    TypeName = AssetTypes.Home,
+                    Value = 375000M,
+                    ValueChange = 0,
+                    Created = DateTime.UtcNow.AddDays(-1)
                 }
             };
         }
@@ -287,12 +324,39 @@ namespace aiof.asset.data
             if (id
                 && userId)
             {
-                foreach (var fakeAssetStok in fakeAssetsStock)
+                foreach (var fakeAssetStock in fakeAssetsStock)
                 {
                     toReturn.Add(new object[]
                     {
-                        fakeAssetStok.Id,
-                        fakeAssetStok.UserId
+                        fakeAssetStock.Id,
+                        fakeAssetStock.UserId
+                    });
+                }
+            }
+
+            return toReturn;
+        }
+
+        public IEnumerable<object[]> GetFakeAssetsHomeData(
+            bool id = false,
+            bool userId = false,
+            bool isDeleted = false)
+        {
+            var fakeAssetsHome = GetFakeAssetsHome()
+                .Where(x => x.IsDeleted == isDeleted)
+                .ToArray();
+
+            var toReturn = new List<object[]>();
+
+            if (id
+                && userId)
+            {
+                foreach (var fakeAssetHome in fakeAssetsHome)
+                {
+                    toReturn.Add(new object[]
+                    {
+                        fakeAssetHome.Id,
+                        fakeAssetHome.UserId
                     });
                 }
             }

--- a/aiof.asset.data/FakeDataManager.cs
+++ b/aiof.asset.data/FakeDataManager.cs
@@ -42,7 +42,7 @@ namespace aiof.asset.data
                 },
                 new AssetType
                 {
-                    Name = AssetTypes.House
+                    Name = AssetTypes.Home
                 },
                 new AssetType
                 {
@@ -81,7 +81,7 @@ namespace aiof.asset.data
                 {
                     Id = 2,
                     Name = "house",
-                    TypeName = AssetTypes.House,
+                    TypeName = AssetTypes.Home,
                     Value = 300000M,
                     UserId = 1,
                     Created = DateTime.UtcNow.AddYears(-5),

--- a/aiof.asset.services/AssetHomeRepository.cs
+++ b/aiof.asset.services/AssetHomeRepository.cs
@@ -1,0 +1,45 @@
+﻿using System;
+using System.Threading.Tasks;
+
+using Microsoft.Extensions.Logging;
+
+using AutoMapper;
+using FluentValidation;
+
+using aiof.asset.data;
+
+namespace aiof.asset.services
+{
+    public class AssetHomeRepository :
+        BaseRepository<AssetHome, AssetHomeDto>,
+        IAssetHomeRepository
+    {
+        private readonly AbstractValidator<AssetHomeDto> _dtoValidator;
+
+        public AssetHomeRepository(
+            ILogger<AssetHomeRepository> logger,
+            IMapper mapper,
+            IEventRepository eventRepo,
+            AssetContext context,
+            AbstractValidator<AssetHomeDto> dtoValidator,
+            AbstractValidator<AssetSnapshotDto> snapshotDtoValidator)
+            : base(logger, mapper, eventRepo, context, snapshotDtoValidator)
+        {
+            _dtoValidator = dtoValidator ?? throw new ArgumentNullException(nameof(dtoValidator));
+        }
+
+        public new async Task<IAsset> AddAsync(AssetHomeDto dto)
+        {
+            await _dtoValidator.ValidateAndThrowAddHomeAsync(dto);
+
+            return await base.AddAsync(dto);
+        }
+
+        public new async Task<IAsset> UpdateAsync(int id, AssetHomeDto dto)
+        {
+            await _dtoValidator.ValidateAndThrowUpdateHomeAsync(dto);
+
+            return await base.UpdateAsync(id, dto);
+        }
+    }
+}

--- a/aiof.asset.services/AssetHomeRepository.cs
+++ b/aiof.asset.services/AssetHomeRepository.cs
@@ -30,9 +30,9 @@ namespace aiof.asset.services
 
         public new async Task<IAsset> AddAsync(AssetHomeDto dto)
         {
-            await _dtoValidator.ValidateAndThrowAddHomeAsync(dto);
-
             dto.TypeName = AssetTypes.Home;
+
+            await _dtoValidator.ValidateAndThrowAddHomeAsync(dto);
 
             return await base.AddAsync(dto);
         }

--- a/aiof.asset.services/AssetHomeRepository.cs
+++ b/aiof.asset.services/AssetHomeRepository.cs
@@ -32,6 +32,8 @@ namespace aiof.asset.services
         {
             await _dtoValidator.ValidateAndThrowAddHomeAsync(dto);
 
+            dto.TypeName = AssetTypes.Home;
+
             return await base.AddAsync(dto);
         }
 

--- a/aiof.asset.services/AssetRepository.cs
+++ b/aiof.asset.services/AssetRepository.cs
@@ -193,6 +193,8 @@ namespace aiof.asset.services
 
         public async Task<IAsset> AddAsync(AssetStockDto dto)
         {
+            dto.TypeName = AssetTypes.Stock;
+
             await _stockDtoValidator.ValidateAndThrowAddStockAsync(dto);
 
             return await AddAsync<AssetStock, AssetStockDto>(dto);
@@ -200,6 +202,8 @@ namespace aiof.asset.services
 
         public async Task<IAsset> AddAsync(AssetHomeDto dto)
         {
+            dto.TypeName = AssetTypes.Home;
+
             await _homeDtoValidator.ValidateAndThrowAddHomeAsync(dto);
 
             return await AddAsync<AssetHome, AssetHomeDto>(dto);
@@ -219,12 +223,16 @@ namespace aiof.asset.services
             // Create snapshot entry
             var snapshotDto = _mapper.Map<AssetSnapshotDto>(dto);
 
-            snapshotDto.AssetId = asset.Id;
+            if (snapshotDto.IsValid())
+            {
+                snapshotDto.AssetId = asset.Id;
 
-            await AddSnapshotAsync(snapshotDto);
+                await AddSnapshotAsync(snapshotDto);
+            }
 
-            _logger.LogInformation("{Tenant} | Created Asset with Id={AssetId}, PublicKey={AssetPublicKey} and UserId={AssetUserId}",
+            _logger.LogInformation("{Tenant} | Created Asset={AssetType} with Id={AssetId}, PublicKey={AssetPublicKey} and UserId={AssetUserId}",
                 _context.Tenant.Log,
+                typeof(TAsset).Name,
                 asset.Id,
                 asset.PublicKey,
                 asset.UserId);
@@ -308,13 +316,17 @@ namespace aiof.asset.services
 
             // Create snapshot entry
             var snapshotDto = _mapper.Map<AssetSnapshotDto>(dto);
+       
+            if (snapshotDto.IsValid())
+            {
+                snapshotDto.AssetId = asset.Id;
 
-            snapshotDto.AssetId = asset.Id;
+                await AddSnapshotAsync(snapshotDto);
+            }
 
-            await AddSnapshotAsync(snapshotDto);
-
-            _logger.LogInformation("{Tenant} | Updated Asset with Id={AssetId}, PublicKey={AssetPublicKey} and UserId={AssetUserId}",
+            _logger.LogInformation("{Tenant} | Updated Asset={AssetType} with Id={AssetId}, PublicKey={AssetPublicKey} and UserId={AssetUserId}",
                 _context.Tenant.Log,
+                typeof(TAsset).Name,
                 asset.Id,
                 asset.PublicKey,
                 asset.UserId);

--- a/aiof.asset.services/AssetRepository.cs
+++ b/aiof.asset.services/AssetRepository.cs
@@ -15,16 +15,13 @@ using aiof.asset.data;
 
 namespace aiof.asset.services
 {
-    public class AssetRepository : IAssetRepository
+    public class AssetRepository : 
+        BaseRepository<Asset, AssetDto>,
+        IAssetRepository
     {
-        private readonly ILogger<AssetRepository> _logger;
-        private readonly IMapper _mapper;
-        private readonly IEventRepository _eventRepo;
         private readonly AssetContext _context;
+
         private readonly AbstractValidator<AssetDto> _dtoValidator;
-        private readonly AbstractValidator<AssetStockDto> _stockDtoValidator;
-        private readonly AbstractValidator<AssetHomeDto> _homeDtoValidator;
-        private readonly AbstractValidator<AssetSnapshotDto> _snapshotDtoValidator;
 
         public AssetRepository(
             ILogger<AssetRepository> logger,
@@ -32,328 +29,74 @@ namespace aiof.asset.services
             IEventRepository eventRepo,
             AssetContext context,
             AbstractValidator<AssetDto> dtoValidator,
-            AbstractValidator<AssetStockDto> stockDtoValidator,
-            AbstractValidator<AssetHomeDto> homeDtoValidator,
             AbstractValidator<AssetSnapshotDto> snapshotDtoValidator)
+            : base(logger, mapper, eventRepo, context, snapshotDtoValidator)
         {
-            _logger = logger ?? throw new ArgumentNullException(nameof(logger));
-            _mapper = mapper ?? throw new ArgumentNullException(nameof(mapper));
-            _eventRepo = eventRepo ?? throw new ArgumentNullException(nameof(eventRepo));
             _context = context ?? throw new ArgumentNullException(nameof(context));
             _dtoValidator = dtoValidator ?? throw new ArgumentNullException(nameof(dtoValidator));
-            _stockDtoValidator = stockDtoValidator ?? throw new ArgumentNullException(nameof(stockDtoValidator));
-            _homeDtoValidator = homeDtoValidator ?? throw new ArgumentNullException(nameof(homeDtoValidator));
-            _snapshotDtoValidator = snapshotDtoValidator ?? throw new ArgumentNullException(nameof(snapshotDtoValidator));
         }
 
-        private IQueryable<AssetType> GetTypesQuery(bool asNoTracking = true)
+        public new async Task<IEnumerable<IAssetType>> GetTypesAsync()
         {
-            var query = _context.AssetTypes
-                .AsQueryable();
-
-            return asNoTracking
-                ? query.AsNoTracking()
-                : query;
-        }
-
-        private IQueryable<Asset> GetBaseQuery(bool asNoTracking = true)
-        {
-            var assetsQuery = _context.Assets;
-
-            return asNoTracking
-                ? assetsQuery.AsNoTracking()
-                : assetsQuery;
-        }
-
-        private IQueryable<AssetSnapshot> GetSnapshotQuery(bool asNoTracking = true)
-        {
-            var assetSnapshotsQuery = _context.AssetSnapshots;
-
-            return asNoTracking
-                ? assetSnapshotsQuery.AsNoTracking()
-                : assetSnapshotsQuery;
-        }
-
-        private IQueryable<Asset> GetQuery(
-            DateTime? snapshotsStartDate = null,
-            DateTime? snapshotsEndDate = null,
-            string type = null,
-            bool asNoTracking = true)
-        {
-            snapshotsStartDate = snapshotsStartDate ?? DateTime.UtcNow.AddMonths(-6);
-            snapshotsEndDate = snapshotsEndDate ?? DateTime.UtcNow;
-
-            if (snapshotsEndDate < snapshotsStartDate)
-                throw new AssetFriendlyException(HttpStatusCode.BadRequest,
-                    $"Snapshots end date cannot be earlier than start date");
-
-            var dbSet = type is null
-                ? _context.Assets.AsQueryable()
-                : _context.Assets.Where(x => x.TypeName == type);
-
-            var assetsQuery = dbSet
-                .Include(x => x.Type)
-                .Include(x => x.Snapshots
-                    .Where(x => x.Created >= snapshotsStartDate && x.Created <= snapshotsEndDate)
-                    .OrderByDescending(x => x.Created));
-
-            return asNoTracking
-                ? assetsQuery.AsNoTracking()
-                : assetsQuery;
-        }
-
-        public async Task<IEnumerable<IAssetType>> GetTypesAsync()
-        {
-            return await GetTypesQuery()
-                .OrderBy(x => x.Name)
-                .ToListAsync();
+            return await base.GetTypesAsync();
         }
 
         public async Task<IAsset> GetAsync(
             int id,
             DateTime? snapshotsStartDate = null,
-            DateTime? snapshotsEndDate = null,
-            bool asNoTracking = true)
+            DateTime? snapshotsEndDate = null)
         {
-            var asset = await GetQuery(snapshotsStartDate, snapshotsEndDate, null, asNoTracking)
-                .FirstOrDefaultAsync(x => x.Id == id)
-                ?? throw new AssetNotFoundException($"Asset with Id={id} was not found");
-
-            if (asset.Snapshots.Count() == 0)
-                asset.Snapshots.Add(await GetLatestSnapshotAsync(asset.Id) as AssetSnapshot);
-
-            return asset;
+            return await base.GetAsync(id, snapshotsStartDate, snapshotsEndDate);
         }
 
         public async Task<IEnumerable<IAsset>> GetAsync(
             DateTime? snapshotsStartDate = null,
             DateTime? snapshotsEndDate = null,
-            string type = null,
-            bool asNoTracking = true)
+            string type = null)
         {
-            return await GetQuery(snapshotsStartDate, snapshotsEndDate, type, asNoTracking)
+            return await base.GetQuery(snapshotsStartDate, snapshotsEndDate, type)
                 .ToListAsync();
         }
 
-        public async Task<IAssetSnapshot> GetLatestSnapshotAsync(
-            int assetId,
-            bool asNoTracking = true)
+        public async Task<IAssetSnapshot> GetLatestSnapshotAsync(int assetId)
         {
-            return await GetSnapshotQuery(asNoTracking)
-                .Where(x => x.AssetId == assetId)
-                .OrderByDescending(x => x.Created)
-                .FirstOrDefaultAsync();
+            return await base.GetLatestSnapshotAsync(assetId);
         }
 
-        public async Task<IAssetSnapshot> GetLatestSnapshotWithValueAsync(
-            int assetId,
-            bool asNoTracking = true)
+        public async Task<IAssetSnapshot> GetLatestSnapshotWithValueAsync(int assetId)
         {
-            return await GetSnapshotQuery(asNoTracking)
-                .Where(x => x.AssetId == assetId
-                    && x.Value.HasValue)
-                .OrderByDescending(x => x.Created)
-                .FirstOrDefaultAsync();
+            return await base.GetLatestSnapshotWithValueAsync(assetId);
         }
 
-        public async Task<IAsset> AddAsync(AssetDto dto)
+        public new async Task<IAsset> AddAsync(AssetDto dto)
         {
             await _dtoValidator.ValidateAndThrowAddAssetAsync(dto);
 
-            return await AddAsync<Asset, AssetDto>(dto);
+            return await base.AddAsync(dto);
         }
 
-        public async Task<IEnumerable<IAsset>> AddAsync(IEnumerable<AssetDto> dtos)
+        public new async Task<IEnumerable<IAsset>> AddAsync(IEnumerable<AssetDto> dtos)
         {
-            if (dtos.Count() > 10)
-                throw new AssetFriendlyException(HttpStatusCode.BadRequest,
-                    $"Cannot add more than 10 Assets at a time");
-
-            var assetsAdded = new List<IAsset>();
-
-            foreach (var dto in dtos)
-            {
-                try
-                {
-                    assetsAdded.Add(await AddAsync(dto));
-                }
-                catch (ValidationException)
-                {
-                    continue;
-                }
-            }
-
-            _logger.LogInformation("{Tenant} | Added {TotalAssets} Assets from total of {TotalDtos} requested",
-                _context.Tenant.Log,
-                assetsAdded.Count(),
-                dtos.Count());
-
-            return assetsAdded.AsEnumerable();
+            return await base.AddAsync(dtos);
         }
 
-        public async Task<IAsset> AddAsync(AssetStockDto dto)
+        public new async Task<IAssetSnapshot> AddSnapshotAsync(AssetSnapshotDto dto)
         {
-            dto.TypeName = AssetTypes.Stock;
-
-            await _stockDtoValidator.ValidateAndThrowAddStockAsync(dto);
-
-            return await AddAsync<AssetStock, AssetStockDto>(dto);
+            return await base.AddSnapshotAsync(dto);
         }
 
-        public async Task<IAsset> AddAsync(AssetHomeDto dto)
-        {
-            dto.TypeName = AssetTypes.Home;
-
-            await _homeDtoValidator.ValidateAndThrowAddHomeAsync(dto);
-
-            return await AddAsync<AssetHome, AssetHomeDto>(dto);
-        }
-
-        private async Task<TAsset> AddAsync<TAsset, TAssetDto>(TAssetDto dto)
-            where TAsset : Asset
-            where TAssetDto : AssetDto
-        {
-            var asset = _mapper.Map<TAsset>(dto);
-
-            asset.UserId = _context.Tenant.UserId;
-
-            await _context.Set<TAsset>().AddAsync(asset);
-            await _context.SaveChangesAsync();
-
-            // Create snapshot entry
-            var snapshotDto = _mapper.Map<AssetSnapshotDto>(dto);
-
-            if (snapshotDto.IsValid())
-            {
-                snapshotDto.AssetId = asset.Id;
-
-                await AddSnapshotAsync(snapshotDto);
-            }
-
-            _logger.LogInformation("{Tenant} | Created Asset={AssetType} with Id={AssetId}, PublicKey={AssetPublicKey} and UserId={AssetUserId}",
-                _context.Tenant.Log,
-                typeof(TAsset).Name,
-                asset.Id,
-                asset.PublicKey,
-                asset.UserId);
-
-            // Emit event
-            await _eventRepo.EmitAsync<AssetAddedEvent>(asset);
-
-            return asset;
-        }
-
-        public async Task<IAssetSnapshot> AddSnapshotAsync(AssetSnapshotDto dto)
-        {
-            await _snapshotDtoValidator.ValidateAndThrowAddSnapshotAsync(dto);
-
-            var snapshot = _mapper.Map<AssetSnapshot>(dto);
-
-            // Calculate ValueChange
-            if (dto.Value.HasValue)
-            {
-                var latestSnapshot = await GetLatestSnapshotWithValueAsync(dto.AssetId);
-                var latestSnapshotValue = latestSnapshot is not null
-                    ? latestSnapshot.Value
-                    : snapshot.ValueChange;
-
-                snapshot.ValueChange = latestSnapshotValue == 0
-                    ? snapshot.ValueChange
-                    : dto.Value - latestSnapshotValue;
-            }
-
-            await _context.AssetSnapshots.AddAsync(snapshot);
-            await _context.SaveChangesAsync();
-
-            _logger.LogInformation("{Tenant} | Created AssetSnapshot for AssetId={AssetId}",
-                _context.Tenant.Log,
-                snapshot.AssetId);
-
-            return snapshot;
-        }
-
-        public async Task<IAsset> UpdateAsync(
+        public new async Task<IAsset> UpdateAsync(
             int id,
             AssetDto dto)
         {
             await _dtoValidator.ValidateAndThrowUpdateAssetAsync(dto);
 
-            return await UpdateAsync<Asset, AssetDto>(id, dto);
+            return await base.UpdateAsync(id, dto);
         }
 
-        public async Task<IAsset> UpdateAsync(
-            int id,
-            AssetStockDto dto)
+        public new async Task DeleteAsync(int id)
         {
-            await _stockDtoValidator.ValidateAndThrowUpdateStockAsync(dto);
-
-            return await UpdateAsync<AssetStock, AssetStockDto>(id, dto);
-        }
-
-        public async Task<IAsset> UpdateAsync(
-            int id,
-            AssetHomeDto dto)
-        {
-            await _homeDtoValidator.ValidateAndThrowUpdateHomeAsync(dto);
-
-            return await UpdateAsync<AssetHome, AssetHomeDto>(id, dto);
-        }
-
-        private async Task<IAsset> UpdateAsync<TAsset, TAssetDto>(
-            int id,
-            TAssetDto dto)
-            where TAsset : Asset
-            where TAssetDto : AssetDto
-        {
-            var asset = await GetAsync(id, asNoTracking: false) as TAsset
-                ?? throw new AssetFriendlyException(HttpStatusCode.BadRequest,
-                    $"Asset is not of type {Constants.ClassToTypeMap[typeof(TAsset).Name]}");
-
-            asset = _mapper.Map(dto, asset);
-
-            _context.Set<TAsset>().Update(asset);
-            await _context.SaveChangesAsync();
-
-            // Create snapshot entry
-            var snapshotDto = _mapper.Map<AssetSnapshotDto>(dto);
-       
-            if (snapshotDto.IsValid())
-            {
-                snapshotDto.AssetId = asset.Id;
-
-                await AddSnapshotAsync(snapshotDto);
-            }
-
-            _logger.LogInformation("{Tenant} | Updated Asset={AssetType} with Id={AssetId}, PublicKey={AssetPublicKey} and UserId={AssetUserId}",
-                _context.Tenant.Log,
-                typeof(TAsset).Name,
-                asset.Id,
-                asset.PublicKey,
-                asset.UserId);
-
-            // Emit event
-            await _eventRepo.EmitAsync<AssetUpdatedEvent>(asset);
-
-            return asset;
-        }
-
-        public async Task DeleteAsync(int id)
-        {
-            var asset = await GetBaseQuery(false)
-                .FirstOrDefaultAsync(x => x.Id == id)
-                ?? throw new AssetNotFoundException($"Asset with Id={id} was not found");
-
-            asset.IsDeleted = true;
-
-            _context.Assets.Update(asset);
-            await _context.SaveChangesAsync();
-
-            _logger.LogInformation("{Tenant} | Soft Deleted Asset with Id={AssetId}",
-                _context.Tenant.Log,
-                id);
-
-            // Emit event
-            await _eventRepo.EmitAsync<AssetDeletedEvent>(asset);
+            await base.DeleteAsync(id);
         }
     }
 }

--- a/aiof.asset.services/AssetRepository.cs
+++ b/aiof.asset.services/AssetRepository.cs
@@ -282,6 +282,15 @@ namespace aiof.asset.services
             return await UpdateAsync<AssetStock, AssetStockDto>(id, dto);
         }
 
+        public async Task<IAsset> UpdateAsync(
+            int id,
+            AssetHomeDto dto)
+        {
+            await _homeDtoValidator.ValidateAndThrowUpdateHomeAsync(dto);
+
+            return await UpdateAsync<AssetHome, AssetHomeDto>(id, dto);
+        }
+
         private async Task<IAsset> UpdateAsync<TAsset, TAssetDto>(
             int id,
             TAssetDto dto)

--- a/aiof.asset.services/AssetRepository.cs
+++ b/aiof.asset.services/AssetRepository.cs
@@ -19,8 +19,6 @@ namespace aiof.asset.services
         BaseRepository<Asset, AssetDto>,
         IAssetRepository
     {
-        private readonly AssetContext _context;
-
         private readonly AbstractValidator<AssetDto> _dtoValidator;
 
         public AssetRepository(
@@ -32,7 +30,6 @@ namespace aiof.asset.services
             AbstractValidator<AssetSnapshotDto> snapshotDtoValidator)
             : base(logger, mapper, eventRepo, context, snapshotDtoValidator)
         {
-            _context = context ?? throw new ArgumentNullException(nameof(context));
             _dtoValidator = dtoValidator ?? throw new ArgumentNullException(nameof(dtoValidator));
         }
 

--- a/aiof.asset.services/AssetRepository.cs
+++ b/aiof.asset.services/AssetRepository.cs
@@ -23,6 +23,7 @@ namespace aiof.asset.services
         private readonly AssetContext _context;
         private readonly AbstractValidator<AssetDto> _dtoValidator;
         private readonly AbstractValidator<AssetStockDto> _stockDtoValidator;
+        private readonly AbstractValidator<AssetHomeDto> _homeDtoValidator;
         private readonly AbstractValidator<AssetSnapshotDto> _snapshotDtoValidator;
 
         public AssetRepository(
@@ -32,6 +33,7 @@ namespace aiof.asset.services
             AssetContext context,
             AbstractValidator<AssetDto> dtoValidator,
             AbstractValidator<AssetStockDto> stockDtoValidator,
+            AbstractValidator<AssetHomeDto> homeDtoValidator,
             AbstractValidator<AssetSnapshotDto> snapshotDtoValidator)
         {
             _logger = logger ?? throw new ArgumentNullException(nameof(logger));
@@ -40,6 +42,7 @@ namespace aiof.asset.services
             _context = context ?? throw new ArgumentNullException(nameof(context));
             _dtoValidator = dtoValidator ?? throw new ArgumentNullException(nameof(dtoValidator));
             _stockDtoValidator = stockDtoValidator ?? throw new ArgumentNullException(nameof(stockDtoValidator));
+            _homeDtoValidator = homeDtoValidator ?? throw new ArgumentNullException(nameof(homeDtoValidator));
             _snapshotDtoValidator = snapshotDtoValidator ?? throw new ArgumentNullException(nameof(snapshotDtoValidator));
         }
 
@@ -193,6 +196,13 @@ namespace aiof.asset.services
             await _stockDtoValidator.ValidateAndThrowAddStockAsync(dto);
 
             return await AddAsync<AssetStock, AssetStockDto>(dto);
+        }
+
+        public async Task<IAsset> AddAsync(AssetHomeDto dto)
+        {
+            await _homeDtoValidator.ValidateAndThrowAddHomeAsync(dto);
+
+            return await AddAsync<AssetHome, AssetHomeDto>(dto);
         }
 
         private async Task<TAsset> AddAsync<TAsset, TAssetDto>(TAssetDto dto)

--- a/aiof.asset.services/AssetRepository.cs
+++ b/aiof.asset.services/AssetRepository.cs
@@ -280,7 +280,7 @@ namespace aiof.asset.services
         {
             var asset = await GetAsync(id, asNoTracking: false) as TAsset
                 ?? throw new AssetFriendlyException(HttpStatusCode.BadRequest,
-                    $"Asset is not of type {Constants.ClassToTypeMap[typeof(AssetStock).Name]}");
+                    $"Asset is not of type {Constants.ClassToTypeMap[typeof(TAsset).Name]}");
 
             asset = _mapper.Map(dto, asset);
 

--- a/aiof.asset.services/AssetRepository.cs
+++ b/aiof.asset.services/AssetRepository.cs
@@ -192,8 +192,6 @@ namespace aiof.asset.services
         {
             await _stockDtoValidator.ValidateAndThrowAddStockAsync(dto);
 
-            dto.TypeName = AssetTypes.Stock;
-
             return await AddAsync<AssetStock, AssetStockDto>(dto);
         }
 

--- a/aiof.asset.services/AssetStockRepository.cs
+++ b/aiof.asset.services/AssetStockRepository.cs
@@ -32,6 +32,8 @@ namespace aiof.asset.services
         {
             await _dtoValidator.ValidateAndThrowAddStockAsync(dto);
 
+            dto.TypeName = AssetTypes.Stock;
+
             return await base.AddAsync(dto);
         }
 

--- a/aiof.asset.services/AssetStockRepository.cs
+++ b/aiof.asset.services/AssetStockRepository.cs
@@ -30,9 +30,9 @@ namespace aiof.asset.services
 
         public new async Task<IAsset> AddAsync(AssetStockDto dto)
         {
-            await _dtoValidator.ValidateAndThrowAddStockAsync(dto);
-
             dto.TypeName = AssetTypes.Stock;
+
+            await _dtoValidator.ValidateAndThrowAddStockAsync(dto);
 
             return await base.AddAsync(dto);
         }

--- a/aiof.asset.services/AssetStockRepository.cs
+++ b/aiof.asset.services/AssetStockRepository.cs
@@ -1,0 +1,45 @@
+﻿using System;
+using System.Threading.Tasks;
+
+using Microsoft.Extensions.Logging;
+
+using AutoMapper;
+using FluentValidation;
+
+using aiof.asset.data;
+
+namespace aiof.asset.services
+{
+    public class AssetStockRepository :
+        BaseRepository<AssetStock, AssetStockDto>,
+        IAssetStockRepository
+    {
+        private readonly AbstractValidator<AssetStockDto> _dtoValidator;
+
+        public AssetStockRepository(
+            ILogger<AssetStockRepository> logger,
+            IMapper mapper,
+            IEventRepository eventRepo,
+            AssetContext context,
+            AbstractValidator<AssetStockDto> dtoValidator,
+            AbstractValidator<AssetSnapshotDto> snapshotDtoValidator)
+            : base(logger, mapper, eventRepo, context, snapshotDtoValidator)
+        {
+            _dtoValidator = dtoValidator ?? throw new ArgumentNullException(nameof(dtoValidator));
+        }
+
+        public new async Task<IAsset> AddAsync(AssetStockDto dto)
+        {
+            await _dtoValidator.ValidateAndThrowAddStockAsync(dto);
+
+            return await base.AddAsync(dto);
+        }
+
+        public new async Task<IAsset> UpdateAsync(int id, AssetStockDto dto)
+        {
+            await _dtoValidator.ValidateAndThrowUpdateStockAsync(dto);
+
+            return await base.UpdateAsync(id, dto);
+        }
+    }
+}

--- a/aiof.asset.services/BaseRepository.cs
+++ b/aiof.asset.services/BaseRepository.cs
@@ -3,7 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Net;
 using System.Threading.Tasks;
-using System.Text.Json;
+using System.Diagnostics.CodeAnalysis;
 
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging;
@@ -15,6 +15,7 @@ using aiof.asset.data;
 
 namespace aiof.asset.services
 {
+    [ExcludeFromCodeCoverage]
     public abstract class BaseRepository<T, TDto>
         where T : Asset
         where TDto : AssetDto

--- a/aiof.asset.services/BaseRepository.cs
+++ b/aiof.asset.services/BaseRepository.cs
@@ -1,0 +1,286 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net;
+using System.Threading.Tasks;
+using System.Text.Json;
+
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+
+using AutoMapper;
+using FluentValidation;
+
+using aiof.asset.data;
+
+namespace aiof.asset.services
+{
+    public abstract class BaseRepository<T, TDto>
+        where T : Asset
+        where TDto : AssetDto
+    {
+        private readonly ILogger _logger;
+        private readonly IMapper _mapper;
+        private readonly IEventRepository _eventRepo;
+        private readonly AssetContext _context;
+        private readonly AbstractValidator<AssetSnapshotDto> _snapshotDtoValidator;
+
+        public BaseRepository(
+            ILogger logger,
+            IMapper mapper,
+            IEventRepository eventRepo,
+            AssetContext context,
+            AbstractValidator<AssetSnapshotDto> snapshotDtoValidator)
+        {
+            _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+            _mapper = mapper ?? throw new ArgumentNullException(nameof(mapper));
+            _eventRepo = eventRepo ?? throw new ArgumentNullException(nameof(eventRepo));
+            _context = context ?? throw new ArgumentNullException(nameof(context));
+            _snapshotDtoValidator = snapshotDtoValidator ?? throw new ArgumentNullException(nameof(snapshotDtoValidator));
+        }
+
+        public IQueryable<AssetType> GetTypesQuery(bool asNoTracking = true)
+        {
+            var query = _context.AssetTypes
+                .AsQueryable();
+
+            return asNoTracking
+                ? query.AsNoTracking()
+                : query;
+        }
+
+        public IQueryable<AssetSnapshot> GetSnapshotQuery(bool asNoTracking = true)
+        {
+            var assetSnapshotsQuery = _context.AssetSnapshots;
+
+            return asNoTracking
+                ? assetSnapshotsQuery.AsNoTracking()
+                : assetSnapshotsQuery;
+        }
+
+        public IQueryable<T> GetBaseQuery(bool asNoTracking = true)
+        {
+            var assetsQuery = _context.Set<T>();
+
+            return asNoTracking
+                ? assetsQuery.AsNoTracking()
+                : assetsQuery;
+        }
+
+        public IQueryable<T> GetQuery(
+            DateTime? snapshotsStartDate = null,
+            DateTime? snapshotsEndDate = null,
+            string type = null,
+            bool asNoTracking = true)
+        {
+            snapshotsStartDate = snapshotsStartDate ?? DateTime.UtcNow.AddMonths(-6);
+            snapshotsEndDate = snapshotsEndDate ?? DateTime.UtcNow;
+
+            if (snapshotsEndDate < snapshotsStartDate)
+                throw new AssetFriendlyException(HttpStatusCode.BadRequest,
+                    $"Snapshots end date cannot be earlier than start date");
+
+            var dbSet = type is null
+                ? _context.Set<T>().AsQueryable()
+                : _context.Set<T>().Where(x => x.TypeName == type);
+
+            var assetsQuery = dbSet
+                .Include(x => x.Type)
+                .Include(x => x.Snapshots
+                    .Where(x => x.Created >= snapshotsStartDate && x.Created <= snapshotsEndDate)
+                    .OrderByDescending(x => x.Created));
+
+            return asNoTracking
+                ? assetsQuery.AsNoTracking()
+                : assetsQuery;
+        }
+
+        public async Task<IEnumerable<IAssetType>> GetTypesAsync()
+        {
+            return await GetTypesQuery()
+                .OrderBy(x => x.Name)
+                .ToListAsync();
+        }
+
+        public async Task<IAssetSnapshot> GetLatestSnapshotAsync(
+            int assetId,
+            bool asNoTracking = true)
+        {
+            return await GetSnapshotQuery(asNoTracking)
+                .Where(x => x.AssetId == assetId)
+                .OrderByDescending(x => x.Created)
+                .FirstOrDefaultAsync();
+        }
+
+        public async Task<IAssetSnapshot> GetLatestSnapshotWithValueAsync(
+            int assetId,
+            bool asNoTracking = true)
+        {
+            return await GetSnapshotQuery(asNoTracking)
+                .Where(x => x.AssetId == assetId
+                    && x.Value.HasValue)
+                .OrderByDescending(x => x.Created)
+                .FirstOrDefaultAsync();
+        }
+
+        public async Task<IAsset> GetAsync(
+            int id,
+            DateTime? snapshotsStartDate = null,
+            DateTime? snapshotsEndDate = null,
+            bool asNoTracking = true)
+        {
+            var asset = await GetQuery(snapshotsStartDate, snapshotsEndDate, null, asNoTracking)
+                .FirstOrDefaultAsync(x => x.Id == id)
+                ?? throw new AssetNotFoundException($"Asset with Id={id} was not found");
+
+            if (asset.Snapshots.Count() == 0)
+                asset.Snapshots.Add(await GetLatestSnapshotAsync(asset.Id) as AssetSnapshot);
+
+            return asset;
+        }
+
+        public async Task<IAsset> AddAsync(TDto dto)
+        {
+            var asset = _mapper.Map<T>(dto);
+
+            asset.UserId = _context.Tenant.UserId;
+
+            await _context.Set<T>().AddAsync(asset);
+            await _context.SaveChangesAsync();
+
+            // Create snapshot entry
+            var snapshotDto = _mapper.Map<AssetSnapshotDto>(dto);
+
+            if (snapshotDto.IsValid())
+            {
+                snapshotDto.AssetId = asset.Id;
+
+                await AddSnapshotAsync(snapshotDto);
+            }
+
+            _logger.LogInformation("{Tenant} | Created Asset={AssetType} with Id={AssetId}, PublicKey={AssetPublicKey} and UserId={AssetUserId}",
+                _context.Tenant.Log,
+                typeof(T).Name,
+                asset.Id,
+                asset.PublicKey,
+                asset.UserId);
+
+            // Emit event
+            await _eventRepo.EmitAsync<AssetAddedEvent>(asset);
+
+            return asset;
+        }
+
+        public async Task<IEnumerable<IAsset>> AddAsync(IEnumerable<TDto> dtos)
+        {
+            if (dtos.Count() > 10)
+                throw new AssetFriendlyException(HttpStatusCode.BadRequest,
+                    $"Cannot add more than 10 Assets at a time");
+
+            var assetsAdded = new List<IAsset>();
+
+            foreach (var dto in dtos)
+            {
+                try
+                {
+                    assetsAdded.Add(await AddAsync(dto));
+                }
+                catch (ValidationException)
+                {
+                    continue;
+                }
+            }
+
+            _logger.LogInformation("{Tenant} | Added {TotalAssets} Assets from total of {TotalDtos} requested",
+                _context.Tenant.Log,
+                assetsAdded.Count(),
+                dtos.Count());
+
+            return assetsAdded.AsEnumerable();
+        }
+
+        public async Task<IAssetSnapshot> AddSnapshotAsync(AssetSnapshotDto dto)
+        {
+            await _snapshotDtoValidator.ValidateAndThrowAddSnapshotAsync(dto);
+
+            var snapshot = _mapper.Map<AssetSnapshot>(dto);
+
+            // Calculate ValueChange
+            if (dto.Value.HasValue)
+            {
+                var latestSnapshot = await GetLatestSnapshotWithValueAsync(dto.AssetId);
+                var latestSnapshotValue = latestSnapshot is not null
+                    ? latestSnapshot.Value
+                    : snapshot.ValueChange;
+
+                snapshot.ValueChange = latestSnapshotValue == 0
+                    ? snapshot.ValueChange
+                    : dto.Value - latestSnapshotValue;
+            }
+
+            await _context.AssetSnapshots.AddAsync(snapshot);
+            await _context.SaveChangesAsync();
+
+            _logger.LogInformation("{Tenant} | Created AssetSnapshot for AssetId={AssetId}",
+                _context.Tenant.Log,
+                snapshot.AssetId);
+
+            return snapshot;
+        }
+
+        public async Task<IAsset> UpdateAsync(
+            int id,
+            TDto dto)
+        {
+            var asset = await GetAsync(id, asNoTracking: false) as T
+                ?? throw new AssetFriendlyException(HttpStatusCode.BadRequest,
+                    $"Asset is not of type {Constants.ClassToTypeMap[typeof(T).Name]}");
+
+            asset = _mapper.Map(dto, asset);
+
+            _context.Set<T>().Update(asset);
+            await _context.SaveChangesAsync();
+
+            // Create snapshot entry
+            var snapshotDto = _mapper.Map<AssetSnapshotDto>(dto);
+       
+            if (snapshotDto.IsValid())
+            {
+                snapshotDto.AssetId = asset.Id;
+
+                await AddSnapshotAsync(snapshotDto);
+            }
+
+            _logger.LogInformation("{Tenant} | Updated Asset={AssetType} with Id={AssetId}, PublicKey={AssetPublicKey} and UserId={AssetUserId}",
+                _context.Tenant.Log,
+                typeof(T).Name,
+                asset.Id,
+                asset.PublicKey,
+                asset.UserId);
+
+            // Emit event
+            await _eventRepo.EmitAsync<AssetUpdatedEvent>(asset);
+
+            return asset;
+        }
+
+        public async Task DeleteAsync(int id)
+        {
+            var asset = await GetBaseQuery(false)
+                .FirstOrDefaultAsync(x => x.Id == id)
+                ?? throw new AssetNotFoundException($"Asset with Id={id} was not found");
+
+            asset.IsDeleted = true;
+
+            _context.Assets.Update(asset);
+            await _context.SaveChangesAsync();
+
+            _logger.LogInformation("{Tenant} | Soft Deleted Asset with Id={AssetId}",
+                _context.Tenant.Log,
+                id);
+
+            // Emit event
+            await _eventRepo.EmitAsync<AssetDeletedEvent>(asset);
+        }
+    }
+}

--- a/aiof.asset.services/EventRepository.cs
+++ b/aiof.asset.services/EventRepository.cs
@@ -64,7 +64,7 @@ namespace aiof.asset.services
             }
             catch (Exception e)
             {
-                _logger.LogError("{Tenant} | Error while emitting event={EventName}. Message={EventingErrorMessage}",
+                _logger.LogError("{Tenant} | Error while emitting event={EventName}. Message={EventErrorMessage}",
                     _tenant.Log,
                     nameof(T),
                     e.Message);

--- a/aiof.asset.services/IAssetHomeRepository.cs
+++ b/aiof.asset.services/IAssetHomeRepository.cs
@@ -1,0 +1,16 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+using aiof.asset.data;
+
+namespace aiof.asset.services
+{
+    public interface IAssetHomeRepository
+    {
+        Task<IAsset> AddAsync(AssetHomeDto dto);
+        Task<IAsset> UpdateAsync(int id, AssetHomeDto dto);
+    }
+}

--- a/aiof.asset.services/IAssetRepository.cs
+++ b/aiof.asset.services/IAssetRepository.cs
@@ -32,6 +32,7 @@ namespace aiof.asset.services
         Task<IAsset> AddAsync(AssetDto dto);
         Task<IEnumerable<IAsset>> AddAsync(IEnumerable<AssetDto> dtos);
         Task<IAsset> AddAsync(AssetStockDto dto);
+        Task<IAsset> AddAsync(AssetHomeDto dto);
 
         Task<IAssetSnapshot> AddSnapshotAsync(AssetSnapshotDto dto);
 

--- a/aiof.asset.services/IAssetRepository.cs
+++ b/aiof.asset.services/IAssetRepository.cs
@@ -42,6 +42,9 @@ namespace aiof.asset.services
         Task<IAsset> UpdateAsync(
             int id,
             AssetStockDto dto);
+        Task<IAsset> UpdateAsync(
+            int id,
+            AssetHomeDto dto);
 
         Task DeleteAsync(int id);
     }

--- a/aiof.asset.services/IAssetRepository.cs
+++ b/aiof.asset.services/IAssetRepository.cs
@@ -15,36 +15,22 @@ namespace aiof.asset.services
         Task<IAsset> GetAsync(
             int id,
             DateTime? snapshotsStartDate = null,
-            DateTime? snapshotsEndDate = null,
-            bool asNoTracking = true);
+            DateTime? snapshotsEndDate = null);
         Task<IEnumerable<IAsset>> GetAsync(
             DateTime? snapshotsStartDate = null,
             DateTime? snapshotsEndDate = null,
-            string type = null,
-            bool asNoTracking = true);
-        Task<IAssetSnapshot> GetLatestSnapshotAsync(
-            int assetId,
-            bool asNoTracking = true);
-        Task<IAssetSnapshot> GetLatestSnapshotWithValueAsync(
-            int assetId,
-            bool asNoTracking = true);
+            string type = null);
+        Task<IAssetSnapshot> GetLatestSnapshotAsync(int assetId);
+        Task<IAssetSnapshot> GetLatestSnapshotWithValueAsync(int assetId);
 
         Task<IAsset> AddAsync(AssetDto dto);
         Task<IEnumerable<IAsset>> AddAsync(IEnumerable<AssetDto> dtos);
-        Task<IAsset> AddAsync(AssetStockDto dto);
-        Task<IAsset> AddAsync(AssetHomeDto dto);
 
         Task<IAssetSnapshot> AddSnapshotAsync(AssetSnapshotDto dto);
 
         Task<IAsset> UpdateAsync(
             int id,
             AssetDto dto);
-        Task<IAsset> UpdateAsync(
-            int id,
-            AssetStockDto dto);
-        Task<IAsset> UpdateAsync(
-            int id,
-            AssetHomeDto dto);
 
         Task DeleteAsync(int id);
     }

--- a/aiof.asset.services/IAssetStockRepository.cs
+++ b/aiof.asset.services/IAssetStockRepository.cs
@@ -1,0 +1,16 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+using aiof.asset.data;
+
+namespace aiof.asset.services
+{
+    public interface IAssetStockRepository
+    {
+        Task<IAsset> AddAsync(AssetStockDto dto);
+        Task<IAsset> UpdateAsync(int id, AssetStockDto dto);
+    }
+}

--- a/aiof.asset.tests/AssetHomeRepository.Tests.cs
+++ b/aiof.asset.tests/AssetHomeRepository.Tests.cs
@@ -1,0 +1,87 @@
+﻿using System;
+using System.Threading.Tasks;
+using System.Linq;
+
+using Xunit;
+
+using aiof.asset.data;
+using aiof.asset.services;
+
+namespace aiof.asset.tests
+{
+    [Trait(Helper.Category, Helper.UnitTest)]
+    public class AssetHomeRepositoryTests
+    {
+        [Theory]
+        [MemberData(nameof(Helper.AssetsUserId), MemberType = typeof(Helper))]
+        public async Task AddAsync_Home_IsSuccessful(int userId)
+        {
+            var repo = new ServiceHelper() { UserId = userId }.GetRequiredService<IAssetHomeRepository>();
+
+            var dto = Helper.RandomAssetHomeDto();
+            var asset = await repo.AddAsync(dto) as AssetHome;
+
+            Assert.NotNull(asset);
+            Assert.NotEqual(0, asset.Id);
+            Assert.NotEqual(Guid.Empty, asset.PublicKey);
+            Assert.Equal(dto.Name, asset.Name);
+            Assert.Equal(AssetTypes.Home, asset.TypeName);
+            Assert.NotNull(asset.Type);
+            Assert.NotEqual(0, asset.Value);
+            Assert.Equal(userId, asset.UserId);
+            Assert.True(asset.Created > new DateTime());
+            Assert.False(asset.IsDeleted);
+            Assert.NotEmpty(asset.Snapshots);
+            Assert.Equal(dto.HomeType, asset.HomeType);
+            Assert.Equal(dto.LoanValue, asset.LoanValue);
+            Assert.Equal(dto.MonthlyMortgage, asset.MonthlyMortgage);
+            Assert.Equal(dto.MortgageRate, asset.MortgageRate);
+            Assert.Equal(dto.DownPayment, asset.DownPayment);
+            Assert.Equal(dto.AnnualInsurance, asset.AnnualInsurance);
+            Assert.Equal(dto.AnnualPropertyTax, asset.AnnualPropertyTax);
+            Assert.Equal(dto.ClosingCosts, asset.ClosingCosts);
+            Assert.False(asset.IsRefinanced);
+        }
+
+        [Theory]
+        [MemberData(nameof(Helper.AssetsHomeIdUserId), MemberType = typeof(Helper))]
+        public async Task UpdateAsync_Home_IsSuccessful(int id, int userId)
+        {
+            var repo = new ServiceHelper() { UserId = userId }.GetRequiredService<IAssetHomeRepository>();
+
+            var dto = Helper.RandomAssetHomeDto();
+
+            var asset = await repo.UpdateAsync(id, dto) as AssetHome;
+
+            Assert.NotNull(asset);
+            Assert.Equal(id, asset.Id);
+            Assert.Equal(dto.Name, asset.Name);
+            Assert.Equal(dto.TypeName, asset.TypeName);
+            Assert.Equal(dto.Value, asset.Value);
+            Assert.Equal(dto.HomeType, asset.HomeType);
+            Assert.Equal(dto.LoanValue, asset.LoanValue);
+            Assert.Equal(dto.MonthlyMortgage, asset.MonthlyMortgage);
+            Assert.Equal(dto.MortgageRate, asset.MortgageRate);
+            Assert.Equal(dto.DownPayment, asset.DownPayment);
+            Assert.Equal(dto.AnnualInsurance, asset.AnnualInsurance);
+            Assert.Equal(dto.AnnualPropertyTax, asset.AnnualPropertyTax);
+            Assert.Equal(dto.ClosingCosts, asset.ClosingCosts);
+            Assert.False(asset.IsRefinanced);
+            Assert.NotNull(asset.Snapshots.First().ValueChange);
+        }
+
+        [Theory]
+        [MemberData(nameof(Helper.AssetsHomeIdUserId), MemberType = typeof(Helper))]
+        public async Task DeleteAsync_Home_IsSuccessful(int id, int userId)
+        {
+            var repo = new ServiceHelper() { UserId = userId }.GetRequiredService<IAssetRepository>();
+
+            await repo.DeleteAsync(id);
+
+            var exception = await Assert.ThrowsAsync<AssetNotFoundException>(() => repo.GetAsync(id));
+
+            Assert.NotNull(exception);
+            Assert.Equal(404, exception.StatusCode);
+        }
+    }
+}

--- a/aiof.asset.tests/AssetRepository.Tests.cs
+++ b/aiof.asset.tests/AssetRepository.Tests.cs
@@ -282,7 +282,7 @@ namespace aiof.asset.tests
             Assert.True(asset.Created > new DateTime());
             Assert.False(asset.IsDeleted);
             Assert.NotEmpty(asset.Snapshots);
-            Assert.NotEmpty(asset.HomeType);
+            Assert.Equal(dto.HomeType, asset.HomeType);
             Assert.Equal(dto.LoanValue, asset.LoanValue);
             Assert.Equal(dto.MonthlyMortgage, asset.MonthlyMortgage);
             Assert.Equal(dto.MortgageRate, asset.MortgageRate);
@@ -461,6 +461,33 @@ namespace aiof.asset.tests
             Assert.Equal(dto.Shares, asset.Shares);
             Assert.Equal(dto.ExpenseRatio, asset.ExpenseRatio);
             Assert.Equal(dto.DividendYield, asset.DividendYield);
+            Assert.NotNull(asset.Snapshots.First().ValueChange);
+        }
+
+        [Theory]
+        [MemberData(nameof(Helper.AssetsHomeIdUserId), MemberType = typeof(Helper))]
+        public async Task UpdateAsync_Home_IsSuccessful(int id, int userId)
+        {
+            var repo = new ServiceHelper() { UserId = userId }.GetRequiredService<IAssetRepository>();
+
+            var dto = Helper.RandomAssetHomeDto();
+
+            var asset = await repo.UpdateAsync(id, dto) as AssetHome;
+
+            Assert.NotNull(asset);
+            Assert.Equal(id, asset.Id);
+            Assert.Equal(dto.Name, asset.Name);
+            Assert.Equal(dto.TypeName, asset.TypeName);
+            Assert.Equal(dto.Value, asset.Value);
+            Assert.Equal(dto.HomeType, asset.HomeType);
+            Assert.Equal(dto.LoanValue, asset.LoanValue);
+            Assert.Equal(dto.MonthlyMortgage, asset.MonthlyMortgage);
+            Assert.Equal(dto.MortgageRate, asset.MortgageRate);
+            Assert.Equal(dto.DownPayment, asset.DownPayment);
+            Assert.Equal(dto.AnnualInsurance, asset.AnnualInsurance);
+            Assert.Equal(dto.AnnualPropertyTax, asset.AnnualPropertyTax);
+            Assert.Equal(dto.ClosingCosts, asset.ClosingCosts);
+            Assert.False(asset.IsRefinanced);
             Assert.NotNull(asset.Snapshots.First().ValueChange);
         }
 

--- a/aiof.asset.tests/AssetRepository.Tests.cs
+++ b/aiof.asset.tests/AssetRepository.Tests.cs
@@ -264,6 +264,37 @@ namespace aiof.asset.tests
 
         [Theory]
         [MemberData(nameof(Helper.AssetsUserId), MemberType = typeof(Helper))]
+        public async Task AddAsync_Home_IsSuccessful(int userId)
+        {
+            var repo = new ServiceHelper() { UserId = userId }.GetRequiredService<IAssetRepository>();
+
+            var dto = Helper.RandomAssetHomeDto();
+            var asset = await repo.AddAsync(dto) as AssetHome;
+
+            Assert.NotNull(asset);
+            Assert.NotEqual(0, asset.Id);
+            Assert.NotEqual(Guid.Empty, asset.PublicKey);
+            Assert.Equal(dto.Name, asset.Name);
+            Assert.Equal(AssetTypes.Home, asset.TypeName);
+            Assert.NotNull(asset.Type);
+            Assert.NotEqual(0, asset.Value);
+            Assert.Equal(userId, asset.UserId);
+            Assert.True(asset.Created > new DateTime());
+            Assert.False(asset.IsDeleted);
+            Assert.NotEmpty(asset.Snapshots);
+            Assert.NotEmpty(asset.HomeType);
+            Assert.Equal(dto.LoanValue, asset.LoanValue);
+            Assert.Equal(dto.MonthlyMortgage, asset.MonthlyMortgage);
+            Assert.Equal(dto.MortgageRate, asset.MortgageRate);
+            Assert.Equal(dto.DownPayment, asset.DownPayment);
+            Assert.Equal(dto.AnnualInsurance, asset.AnnualInsurance);
+            Assert.Equal(dto.AnnualPropertyTax, asset.AnnualPropertyTax);
+            Assert.Equal(dto.ClosingCosts, asset.ClosingCosts);
+            Assert.False(asset.IsRefinanced);
+        }
+
+        [Theory]
+        [MemberData(nameof(Helper.AssetsUserId), MemberType = typeof(Helper))]
         public async Task AddAsync_UpdateAsync_IsSuccessful(int userId)
         {
             var repo = new ServiceHelper() { UserId = userId }.GetRequiredService<IAssetRepository>();

--- a/aiof.asset.tests/AssetRepository.Tests.cs
+++ b/aiof.asset.tests/AssetRepository.Tests.cs
@@ -231,70 +231,6 @@ namespace aiof.asset.tests
 
         [Theory]
         [MemberData(nameof(Helper.AssetsUserId), MemberType = typeof(Helper))]
-        public async Task AddAsync_Stock_IsSuccessful(int userId)
-        {
-            var repo = new ServiceHelper() { UserId = userId }.GetRequiredService<IAssetRepository>();
-
-            var dto = Helper.RandomAssetStockDto();
-            var asset = await repo.AddAsync(dto) as AssetStock;
-
-            Assert.NotNull(asset);
-            Assert.NotEqual(0, asset.Id);
-            Assert.NotEqual(Guid.Empty, asset.PublicKey);
-            Assert.Equal(dto.Name, asset.Name);
-            Assert.Equal(AssetTypes.Stock, asset.TypeName);
-            Assert.NotNull(asset.Type);
-            Assert.NotEqual(0, asset.Value);
-            Assert.Equal(userId, asset.UserId);
-            Assert.False(asset.IsDeleted);
-            Assert.NotEmpty(asset.Snapshots);
-            Assert.Equal(dto.TickerSymbol, asset.TickerSymbol);
-            Assert.Equal(dto.Shares, asset.Shares);
-            Assert.Equal(dto.ExpenseRatio, asset.ExpenseRatio);
-            Assert.Equal(dto.DividendYield, asset.DividendYield);
-
-            var snapshots = asset.Snapshots;
-            var snapshot = snapshots?.FirstOrDefault();
-
-            Assert.Equal(dto.Name, snapshot.Name);
-            Assert.Equal(dto.TypeName, snapshot.TypeName);
-            Assert.Equal(dto.Value, snapshot.Value);
-            Assert.Equal(0, snapshot.ValueChange);
-        }
-
-        [Theory]
-        [MemberData(nameof(Helper.AssetsUserId), MemberType = typeof(Helper))]
-        public async Task AddAsync_Home_IsSuccessful(int userId)
-        {
-            var repo = new ServiceHelper() { UserId = userId }.GetRequiredService<IAssetRepository>();
-
-            var dto = Helper.RandomAssetHomeDto();
-            var asset = await repo.AddAsync(dto) as AssetHome;
-
-            Assert.NotNull(asset);
-            Assert.NotEqual(0, asset.Id);
-            Assert.NotEqual(Guid.Empty, asset.PublicKey);
-            Assert.Equal(dto.Name, asset.Name);
-            Assert.Equal(AssetTypes.Home, asset.TypeName);
-            Assert.NotNull(asset.Type);
-            Assert.NotEqual(0, asset.Value);
-            Assert.Equal(userId, asset.UserId);
-            Assert.True(asset.Created > new DateTime());
-            Assert.False(asset.IsDeleted);
-            Assert.NotEmpty(asset.Snapshots);
-            Assert.Equal(dto.HomeType, asset.HomeType);
-            Assert.Equal(dto.LoanValue, asset.LoanValue);
-            Assert.Equal(dto.MonthlyMortgage, asset.MonthlyMortgage);
-            Assert.Equal(dto.MortgageRate, asset.MortgageRate);
-            Assert.Equal(dto.DownPayment, asset.DownPayment);
-            Assert.Equal(dto.AnnualInsurance, asset.AnnualInsurance);
-            Assert.Equal(dto.AnnualPropertyTax, asset.AnnualPropertyTax);
-            Assert.Equal(dto.ClosingCosts, asset.ClosingCosts);
-            Assert.False(asset.IsRefinanced);
-        }
-
-        [Theory]
-        [MemberData(nameof(Helper.AssetsUserId), MemberType = typeof(Helper))]
         public async Task AddAsync_UpdateAsync_IsSuccessful(int userId)
         {
             var repo = new ServiceHelper() { UserId = userId }.GetRequiredService<IAssetRepository>();
@@ -443,55 +379,6 @@ namespace aiof.asset.tests
         }
 
         [Theory]
-        [MemberData(nameof(Helper.AssetsStockIdUserId), MemberType = typeof(Helper))]
-        public async Task UpdateAsync_Stock_IsSuccessful(int id, int userId)
-        {
-            var repo = new ServiceHelper() { UserId = userId }.GetRequiredService<IAssetRepository>();
-
-            var dto = Helper.RandomAssetStockDto();
-
-            var asset = await repo.UpdateAsync(id, dto) as AssetStock;
-
-            Assert.NotNull(asset);
-            Assert.Equal(id, asset.Id);
-            Assert.Equal(dto.Name, asset.Name);
-            Assert.Equal(dto.TypeName, asset.TypeName);
-            Assert.Equal(dto.Value, asset.Value);
-            Assert.Equal(dto.TickerSymbol, asset.TickerSymbol);
-            Assert.Equal(dto.Shares, asset.Shares);
-            Assert.Equal(dto.ExpenseRatio, asset.ExpenseRatio);
-            Assert.Equal(dto.DividendYield, asset.DividendYield);
-            Assert.NotNull(asset.Snapshots.First().ValueChange);
-        }
-
-        [Theory]
-        [MemberData(nameof(Helper.AssetsHomeIdUserId), MemberType = typeof(Helper))]
-        public async Task UpdateAsync_Home_IsSuccessful(int id, int userId)
-        {
-            var repo = new ServiceHelper() { UserId = userId }.GetRequiredService<IAssetRepository>();
-
-            var dto = Helper.RandomAssetHomeDto();
-
-            var asset = await repo.UpdateAsync(id, dto) as AssetHome;
-
-            Assert.NotNull(asset);
-            Assert.Equal(id, asset.Id);
-            Assert.Equal(dto.Name, asset.Name);
-            Assert.Equal(dto.TypeName, asset.TypeName);
-            Assert.Equal(dto.Value, asset.Value);
-            Assert.Equal(dto.HomeType, asset.HomeType);
-            Assert.Equal(dto.LoanValue, asset.LoanValue);
-            Assert.Equal(dto.MonthlyMortgage, asset.MonthlyMortgage);
-            Assert.Equal(dto.MortgageRate, asset.MortgageRate);
-            Assert.Equal(dto.DownPayment, asset.DownPayment);
-            Assert.Equal(dto.AnnualInsurance, asset.AnnualInsurance);
-            Assert.Equal(dto.AnnualPropertyTax, asset.AnnualPropertyTax);
-            Assert.Equal(dto.ClosingCosts, asset.ClosingCosts);
-            Assert.False(asset.IsRefinanced);
-            Assert.NotNull(asset.Snapshots.First().ValueChange);
-        }
-
-        [Theory]
         [MemberData(nameof(Helper.AssetsIdUserId), MemberType = typeof(Helper))]
         public async Task UpdateAsync_NotFound_ThrowsAssetNotFoundException(int id, int userId)
         {
@@ -615,20 +502,6 @@ namespace aiof.asset.tests
         [Theory]
         [MemberData(nameof(Helper.AssetsIdUserId), MemberType = typeof(Helper))]
         public async Task DeleteAsync_IsSuccessful(int id, int userId)
-        {
-            var repo = new ServiceHelper() { UserId = userId }.GetRequiredService<IAssetRepository>();
-
-            await repo.DeleteAsync(id);
-
-            var exception = await Assert.ThrowsAsync<AssetNotFoundException>(() => repo.GetAsync(id));
-
-            Assert.NotNull(exception);
-            Assert.Equal(404, exception.StatusCode);
-        }
-
-        [Theory]
-        [MemberData(nameof(Helper.AssetsStockIdUserId), MemberType = typeof(Helper))]
-        public async Task DeleteAsync_Stock_IsSuccessful(int id, int userId)
         {
             var repo = new ServiceHelper() { UserId = userId }.GetRequiredService<IAssetRepository>();
 

--- a/aiof.asset.tests/AssetStockRepository.Tests.cs
+++ b/aiof.asset.tests/AssetStockRepository.Tests.cs
@@ -1,0 +1,84 @@
+﻿using System;
+using System.Threading.Tasks;
+using System.Linq;
+
+using Xunit;
+
+using aiof.asset.data;
+using aiof.asset.services;
+
+namespace aiof.asset.tests
+{
+    [Trait(Helper.Category, Helper.UnitTest)]
+    public class AssetStockRepositoryTests
+    {
+        [Theory]
+        [MemberData(nameof(Helper.AssetsUserId), MemberType = typeof(Helper))]
+        public async Task AddAsync_Stock_IsSuccessful(int userId)
+        {
+            var repo = new ServiceHelper() { UserId = userId }.GetRequiredService<IAssetStockRepository>();
+
+            var dto = Helper.RandomAssetStockDto();
+            var asset = await repo.AddAsync(dto) as AssetStock;
+
+            Assert.NotNull(asset);
+            Assert.NotEqual(0, asset.Id);
+            Assert.NotEqual(Guid.Empty, asset.PublicKey);
+            Assert.Equal(dto.Name, asset.Name);
+            Assert.Equal(AssetTypes.Stock, asset.TypeName);
+            Assert.NotNull(asset.Type);
+            Assert.NotEqual(0, asset.Value);
+            Assert.Equal(userId, asset.UserId);
+            Assert.False(asset.IsDeleted);
+            Assert.NotEmpty(asset.Snapshots);
+            Assert.Equal(dto.TickerSymbol, asset.TickerSymbol);
+            Assert.Equal(dto.Shares, asset.Shares);
+            Assert.Equal(dto.ExpenseRatio, asset.ExpenseRatio);
+            Assert.Equal(dto.DividendYield, asset.DividendYield);
+
+            var snapshots = asset.Snapshots;
+            var snapshot = snapshots?.FirstOrDefault();
+
+            Assert.Equal(dto.Name, snapshot.Name);
+            Assert.Equal(dto.TypeName, snapshot.TypeName);
+            Assert.Equal(dto.Value, snapshot.Value);
+            Assert.Equal(0, snapshot.ValueChange);
+        }
+
+        [Theory]
+        [MemberData(nameof(Helper.AssetsStockIdUserId), MemberType = typeof(Helper))]
+        public async Task UpdateAsync_Stock_IsSuccessful(int id, int userId)
+        {
+            var repo = new ServiceHelper() { UserId = userId }.GetRequiredService<IAssetStockRepository>();
+
+            var dto = Helper.RandomAssetStockDto();
+
+            var asset = await repo.UpdateAsync(id, dto) as AssetStock;
+
+            Assert.NotNull(asset);
+            Assert.Equal(id, asset.Id);
+            Assert.Equal(dto.Name, asset.Name);
+            Assert.Equal(dto.TypeName, asset.TypeName);
+            Assert.Equal(dto.Value, asset.Value);
+            Assert.Equal(dto.TickerSymbol, asset.TickerSymbol);
+            Assert.Equal(dto.Shares, asset.Shares);
+            Assert.Equal(dto.ExpenseRatio, asset.ExpenseRatio);
+            Assert.Equal(dto.DividendYield, asset.DividendYield);
+            Assert.NotNull(asset.Snapshots.First().ValueChange);
+        }
+
+        [Theory]
+        [MemberData(nameof(Helper.AssetsStockIdUserId), MemberType = typeof(Helper))]
+        public async Task DeleteAsync_Stock_IsSuccessful(int id, int userId)
+        {
+            var repo = new ServiceHelper() { UserId = userId }.GetRequiredService<IAssetRepository>();
+
+            await repo.DeleteAsync(id);
+
+            var exception = await Assert.ThrowsAsync<AssetNotFoundException>(() => repo.GetAsync(id));
+
+            Assert.NotNull(exception);
+            Assert.Equal(404, exception.StatusCode);
+        }
+    }
+}

--- a/aiof.asset.tests/AssetValidator.Tests.cs
+++ b/aiof.asset.tests/AssetValidator.Tests.cs
@@ -17,6 +17,7 @@ namespace aiof.asset.tests
         private readonly AbstractValidator<string> _typeValidator;
         private readonly AbstractValidator<AssetDto> _dtoValidator;
         private readonly AbstractValidator<AssetStockDto> _stockDtoValidator;
+        private readonly AbstractValidator<AssetHomeDto> _homeDtoValidator;
         private readonly AbstractValidator<AssetSnapshotDto> _snapshotValidator;
 
         private const int _defaultAssetId = 1;
@@ -28,6 +29,7 @@ namespace aiof.asset.tests
             _typeValidator = service.GetRequiredService<AbstractValidator<string>>() ?? throw new ArgumentNullException(nameof(AbstractValidator<string>));
             _dtoValidator = service.GetRequiredService<AbstractValidator<AssetDto>>() ?? throw new ArgumentNullException(nameof(AbstractValidator<AssetDto>));
             _stockDtoValidator = service.GetRequiredService<AbstractValidator<AssetStockDto>>() ?? throw new ArgumentNullException(nameof(AbstractValidator<AssetStockDto>));
+            _homeDtoValidator = service.GetRequiredService<AbstractValidator<AssetHomeDto>>() ?? throw new ArgumentNullException(nameof(AbstractValidator<AssetHomeDto>));
             _snapshotValidator = service.GetRequiredService<AbstractValidator<AssetSnapshotDto>>() ?? throw new ArgumentNullException(nameof(AbstractValidator<AssetSnapshotDto>));
         }
 
@@ -286,6 +288,19 @@ namespace aiof.asset.tests
             };
 
             Assert.False((await _stockDtoValidator.ValidateUpdateStockAsync(dto)).IsValid);
+        }
+        #endregion
+
+        #region AssetHomeDto
+        [Theory]
+        [MemberData(nameof(Helper.ValidNames), MemberType = typeof(Helper))]
+        public async Task AssetHomeDto_Add_Validation_Name_IsValid(string name)
+        {
+            var dto = Helper.RandomAssetHomeDto();
+
+            dto.Name = name;
+
+            Assert.True((await _homeDtoValidator.ValidateAddHomeAsync(dto)).IsValid);
         }
         #endregion
 

--- a/aiof.asset.tests/AssetValidator.Tests.cs
+++ b/aiof.asset.tests/AssetValidator.Tests.cs
@@ -301,6 +301,26 @@ namespace aiof.asset.tests
             dto.Name = name;
 
             Assert.True((await _homeDtoValidator.ValidateAddHomeAsync(dto)).IsValid);
+            Assert.NotNull(dto.HomeType);
+            Assert.True(dto.LoanValue > CommonValidator.MinimumValue);
+            Assert.True(dto.MonthlyMortgage > CommonValidator.MinimumValue);
+            Assert.True(dto.MortgageRate > CommonValidator.MinimumPercentValue);
+            Assert.True(dto.DownPayment > CommonValidator.MinimumValue);
+            Assert.True(dto.AnnualInsurance > CommonValidator.MinimumValue);
+            Assert.True(dto.AnnualPropertyTax > CommonValidator.MinimumPercentValue);
+            Assert.True(dto.ClosingCosts > CommonValidator.MinimumValue);
+            Assert.False(dto.IsRefinanced);
+        }
+
+        [Theory]
+        [MemberData(nameof(Helper.InvalidNames), MemberType = typeof(Helper))]
+        public async Task AssetHomeDto_Add_Validation_Name_IsInvalid(string name)
+        {
+            var dto = Helper.RandomAssetHomeDto();
+
+            dto.Name = name;
+
+            Assert.False((await _homeDtoValidator.ValidateAddHomeAsync(dto)).IsValid);
         }
         #endregion
 

--- a/aiof.asset.tests/AssetValidator.Tests.cs
+++ b/aiof.asset.tests/AssetValidator.Tests.cs
@@ -201,7 +201,7 @@ namespace aiof.asset.tests
 
         [Theory]
         [MemberData(nameof(Helper.ValidShares), MemberType = typeof(Helper))]
-        public async Task AssetStockDto_Add_Validation_Shares_IsValid(double shares)
+        public async Task AssetStockDto_Add_Validation_Shares_IsValid(decimal shares)
         {
             var dto = Helper.RandomAssetStockDto();
 
@@ -211,7 +211,7 @@ namespace aiof.asset.tests
         }
         [Theory]
         [MemberData(nameof(Helper.InvalidShares), MemberType = typeof(Helper))]
-        public async Task AssetStockDto_Add_Validation_Shares_IsInvalid(double shares)
+        public async Task AssetStockDto_Add_Validation_Shares_IsInvalid(decimal shares)
         {
             var dto = Helper.RandomAssetStockDto();
 
@@ -222,7 +222,7 @@ namespace aiof.asset.tests
 
         [Theory]
         [MemberData(nameof(Helper.ValidExpenseRatios), MemberType = typeof(Helper))]
-        public async Task AssetStockDto_Add_Validation_ExpenseRatio_IsValid(double expenseRatio)
+        public async Task AssetStockDto_Add_Validation_ExpenseRatio_IsValid(decimal expenseRatio)
         {
             var dto = Helper.RandomAssetStockDto();
 
@@ -232,7 +232,7 @@ namespace aiof.asset.tests
         }
         [Theory]
         [MemberData(nameof(Helper.InvalidExpenseRatios), MemberType = typeof(Helper))]
-        public async Task AssetStockDto_Add_Validation_ExpenseRatio_IsInvalid(double expenseRatio)
+        public async Task AssetStockDto_Add_Validation_ExpenseRatio_IsInvalid(decimal expenseRatio)
         {
             var dto = Helper.RandomAssetStockDto();
 
@@ -243,7 +243,7 @@ namespace aiof.asset.tests
 
         [Theory]
         [MemberData(nameof(Helper.ValidExpenseRatios), MemberType = typeof(Helper))]
-        public async Task AssetStockDto_Add_Validation_DividendYield_IsValid(double dividendYield)
+        public async Task AssetStockDto_Add_Validation_DividendYield_IsValid(decimal dividendYield)
         {
             var dto = Helper.RandomAssetStockDto();
 
@@ -253,7 +253,7 @@ namespace aiof.asset.tests
         }
         [Theory]
         [MemberData(nameof(Helper.InvalidExpenseRatios), MemberType = typeof(Helper))]
-        public async Task AssetStockDto_Add_Validation_DividendYield_IsInvalid(double dividendYield)
+        public async Task AssetStockDto_Add_Validation_DividendYield_IsInvalid(decimal dividendYield)
         {
             var dto = Helper.RandomAssetStockDto();
 

--- a/aiof.asset.tests/AutoMappingProfile.Tests.cs
+++ b/aiof.asset.tests/AutoMappingProfile.Tests.cs
@@ -108,6 +108,48 @@ namespace aiof.asset.tests
             Assert.NotNull(assetSnapshotDto.Name);
             Assert.NotNull(assetSnapshotDto.TypeName);
             Assert.NotNull(assetSnapshotDto.Value);
+            Assert.Equal(assetSnapshotDto.Name, assetStockDto.Name);
+            Assert.Equal(assetSnapshotDto.TypeName, assetStockDto.TypeName);
+            Assert.Equal(assetSnapshotDto.Value, assetStockDto.Value);
+        }
+
+        [Fact]
+        public void AssetHomeDto_To_AssetHome_IsSuccessful()
+        {
+            var assetHomeDto = Helper.RandomAssetHomeDto();
+            var assetHome = _mapper.Map<AssetHome>(assetHomeDto);
+
+            Assert.NotNull(assetHome);
+            Assert.NotNull(assetHome.Name);
+            Assert.NotNull(assetHome.TypeName);
+            Assert.True(assetHome.Value > 0);
+            Assert.Equal(assetHome.Name, assetHomeDto.Name);
+            Assert.Equal(assetHome.TypeName, assetHomeDto.TypeName);
+            Assert.Equal(assetHome.Value, assetHomeDto.Value);
+            Assert.NotNull(assetHome.HomeType);
+            Assert.True(assetHome.LoanValue > CommonValidator.MinimumValue);
+            Assert.True(assetHome.MonthlyMortgage > CommonValidator.MinimumValue);
+            Assert.True(assetHome.MortgageRate > CommonValidator.MinimumPercentValue);
+            Assert.True(assetHome.DownPayment > CommonValidator.MinimumValue);
+            Assert.True(assetHome.AnnualInsurance > CommonValidator.MinimumValue);
+            Assert.True(assetHome.AnnualPropertyTax > CommonValidator.MinimumPercentValue);
+            Assert.True(assetHome.ClosingCosts > CommonValidator.MinimumValue);
+            Assert.False(assetHome.IsRefinanced);
+        }
+
+        [Fact]
+        public void AssetHomeDto_To_AssetSnapshotDto_IsSuccessful()
+        {
+            var assetHomeDto = Helper.RandomAssetHomeDto();
+            var assetSnapshotDto = _mapper.Map<AssetSnapshotDto>(assetHomeDto);
+
+            Assert.NotNull(assetSnapshotDto);
+            Assert.NotNull(assetSnapshotDto.Name);
+            Assert.NotNull(assetSnapshotDto.TypeName);
+            Assert.NotNull(assetSnapshotDto.Value);
+            Assert.Equal(assetSnapshotDto.Name, assetHomeDto.Name);
+            Assert.Equal(assetSnapshotDto.TypeName, assetHomeDto.TypeName);
+            Assert.Equal(assetSnapshotDto.Value, assetHomeDto.Value);
         }
     }
 }

--- a/aiof.asset.tests/Helper.cs
+++ b/aiof.asset.tests/Helper.cs
@@ -53,6 +53,8 @@ namespace aiof.asset.tests
             var services = new ServiceCollection();
 
             services.AddScoped<IAssetRepository, AssetRepository>()
+                .AddScoped<IAssetStockRepository, AssetStockRepository>()
+                .AddScoped<IAssetHomeRepository, AssetHomeRepository>()
                 .AddScoped<IEventRepository, EventRepository>()
                 .AddScoped<IEnvConfiguration, EnvConfiguration>()
                 .AddScoped<ITenant, Tenant>()

--- a/aiof.asset.tests/Helper.cs
+++ b/aiof.asset.tests/Helper.cs
@@ -345,9 +345,9 @@ namespace aiof.asset.tests
                 .RuleFor(x => x.TypeName, f => AssetTypes.Stock)
                 .RuleFor(x => x.Value, f => f.Random.Int(1000, 10000))
                 .RuleFor(x => x.TickerSymbol, f => f.Random.String2(5))
-                .RuleFor(x => x.Shares, f => Math.Round(f.Random.Double(10, 150), 2))
-                .RuleFor(x => x.ExpenseRatio, f => Math.Round(f.Random.Double(0.001, 0.005), 5))
-                .RuleFor(x => x.DividendYield, f => Math.Round(f.Random.Double(0.001, 0.05), 5));
+                .RuleFor(x => x.Shares, f => Math.Round(f.Random.Decimal(10, 150), 2))
+                .RuleFor(x => x.ExpenseRatio, f => Math.Round(f.Random.Decimal(0.001M, 0.005M), 5))
+                .RuleFor(x => x.DividendYield, f => Math.Round(f.Random.Decimal(0.001M, 0.05M), 5));
         }
 
         public static AssetHomeDto RandomAssetHomeDto()

--- a/aiof.asset.tests/Helper.cs
+++ b/aiof.asset.tests/Helper.cs
@@ -361,12 +361,16 @@ namespace aiof.asset.tests
         private static Faker<AssetHomeDto> FakerAssetHomeDtos()
         {
             return new Faker<AssetHomeDto>()
+                .RuleFor(x => x.Name, f => f.Random.String2(10))
+                .RuleFor(x => x.TypeName, f => AssetTypes.Home)
+                .RuleFor(x => x.Value, f => f.Random.Int(1000, 10000))
                 .RuleFor(x => x.HomeType, f => f.Random.String2(10))
                 .RuleFor(x => x.LoanValue, f => Math.Round(f.Random.Decimal(150000, 1000000), 3))
                 .RuleFor(x => x.MonthlyMortgage, f => Math.Round(f.Random.Decimal(1500, 2500), 3))
+                .RuleFor(x => x.MortgageRate, f => Math.Round(f.Random.Decimal(1, 1), 3))
                 .RuleFor(x => x.DownPayment, f => Math.Round(f.Random.Decimal(20000, 50000), 3))
                 .RuleFor(x => x.AnnualInsurance, f => f.Random.Decimal(1000, 1500))
-                .RuleFor(x => x.AnnualInsurance, f => f.Random.Decimal(1, 3))
+                .RuleFor(x => x.AnnualPropertyTax, f => f.Random.Decimal(1, 3))
                 .RuleFor(x => x.ClosingCosts, f => f.Random.Decimal(10000, 20000))
                 .RuleFor(x => x.IsRefinanced, f => false);
         }

--- a/aiof.asset.tests/Helper.cs
+++ b/aiof.asset.tests/Helper.cs
@@ -148,6 +148,13 @@ namespace aiof.asset.tests
                 userId: true);
         }
 
+        public static IEnumerable<object[]> AssetsHomeIdUserId()
+        {
+            return _Fake.GetFakeAssetsHomeData(
+                id: true,
+                userId: true);
+        }
+
         public static IEnumerable<object[]> AssetsId()
         {
             return _Fake.GetFakeAssetsData(

--- a/aiof.asset.tests/Helper.cs
+++ b/aiof.asset.tests/Helper.cs
@@ -81,7 +81,8 @@ namespace aiof.asset.tests
             services.AddScoped<AbstractValidator<string>, AssetTypeValidator>()
                 .AddScoped<AbstractValidator<AssetDto>, AssetDtoValidator>()
                 .AddScoped<AbstractValidator<AssetSnapshotDto>, AssetSnapshotDtoValidator>()
-                .AddScoped<AbstractValidator<AssetStockDto>, AssetStockDtoValidator>();
+                .AddScoped<AbstractValidator<AssetStockDto>, AssetStockDtoValidator>()
+                .AddScoped<AbstractValidator<AssetHomeDto>, AssetHomeDtoValidator>();
 
             services.AddLogging();
             services.AddFeatureManagement();
@@ -347,6 +348,27 @@ namespace aiof.asset.tests
                 .RuleFor(x => x.Shares, f => Math.Round(f.Random.Double(10, 150), 2))
                 .RuleFor(x => x.ExpenseRatio, f => Math.Round(f.Random.Double(0.001, 0.005), 5))
                 .RuleFor(x => x.DividendYield, f => Math.Round(f.Random.Double(0.001, 0.05), 5));
+        }
+
+        public static AssetHomeDto RandomAssetHomeDto()
+        {
+            return FakerAssetHomeDtos().Generate();
+        }
+        public static List<AssetHomeDto> RandomAssetHomeDtos(int? n = null)
+        {
+            return FakerAssetHomeDtos().Generate(n ?? GeneratedAmount);
+        }
+        private static Faker<AssetHomeDto> FakerAssetHomeDtos()
+        {
+            return new Faker<AssetHomeDto>()
+                .RuleFor(x => x.HomeType, f => f.Random.String2(10))
+                .RuleFor(x => x.LoanValue, f => Math.Round(f.Random.Decimal(150000, 1000000), 3))
+                .RuleFor(x => x.MonthlyMortgage, f => Math.Round(f.Random.Decimal(1500, 2500), 3))
+                .RuleFor(x => x.DownPayment, f => Math.Round(f.Random.Decimal(20000, 50000), 3))
+                .RuleFor(x => x.AnnualInsurance, f => f.Random.Decimal(1000, 1500))
+                .RuleFor(x => x.AnnualInsurance, f => f.Random.Decimal(1, 3))
+                .RuleFor(x => x.ClosingCosts, f => f.Random.Decimal(10000, 20000))
+                .RuleFor(x => x.IsRefinanced, f => false);
         }
 
         public static AssetSnapshotDto RandomAssetSnapshotDto(int assetId)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ version: "3.9"
 
 services:
   aiofdata:
-    image: aiof-data:latest
+    image: gkama/aiof-data:latest
     container_name: aiof-data
     ports:
       - 5433:5432


### PR DESCRIPTION
Feature to add support for `Asset.Home`. 

- Controller endpoints to add and update Home DTO
- Repository logic to add and update Home DTO
- Home DTO validator

Involves additional work

- Refactored to use an abstract `BaseRepository` and area specific repositories, such as `HomeRepository`
- Updated the controllers and unit tests to reflect that change